### PR TITLE
Feedback integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -1394,7 +1394,7 @@ tr:nth-child(2n+1) > td {
         <h3 id="name-usage-of-decentralized-iden">
 <a href="#section-2.6" class="section-number selfRef">2.6. </a><a href="#name-usage-of-decentralized-iden" class="section-name selfRef">Usage of Decentralized Identifiers</a>
         </h3>
-<p id="section-2.6-1"><a href="https://w3c.github.io/did-core/">Decentralized identifiers</a> are a resolvable identifier to a set of statements about the [did subject]() including a set of cryptographic material (e.g public keys). Using this cryptographic material, a <a href="https://w3c.github.io/did-core/">decentralized identifier</a> can be used as an authenticatable identifier in a credential.<a href="#section-2.6-1" class="pilcrow">¶</a></p>
+<p id="section-2.6-1"><a href="https://w3c.github.io/did-core/">Decentralized identifiers</a> are a resolvable identifier to a set of statements about the <a href="https://w3c.github.io/did-core/#dfn-did-subjects">did subject</a> including a set of cryptographic material (e.g public keys). Using this cryptographic material, a <a href="https://w3c.github.io/did-core/">decentralized identifier</a> can be used as an authenticatable identifier in a credential.<a href="#section-2.6-1" class="pilcrow">¶</a></p>
 <p id="section-2.6-2">The below section highlights how a client construct a credential request to obtain a credential that is bound to the client via the usage of a <a href="https://w3c.github.io/did-core/">decentralized identifier</a>.<a href="#section-2.6-2" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -1549,11 +1549,12 @@ tr:nth-child(2n+1) > td {
       <h2 id="name-credential-offer">
 <a href="#section-4" class="section-number selfRef">4. </a><a href="#name-credential-offer" class="section-name selfRef">Credential Offer</a>
       </h2>
-<p id="section-4-1">The openid-configuration for an OpenID provider is used to communicate to Clients what capabilities the provider supports, including whether or not it supports the credential issuance flow. Sometime it is desirable to be able to embedded a link to an offer that is invocable by supported Clients.<a href="#section-4-1" class="pilcrow">¶</a></p>
-<p id="section-4-2">The following is a non-normative example of a invocable URL pointing to a credential offer offered by the OpenID Provider <code>issuer.example.com</code><a href="#section-4-2" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-4-3">
+<p id="section-4-1"><strong>NOTE this section is still a W.I.P</strong><a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-4-2">The openid-configuration for an OpenID provider is used to communicate to Clients what capabilities the provider supports, including whether or not it supports the credential issuance flow. Sometime it is desirable to be able to embedded a link to an offer that is invocable by supported Clients.<a href="#section-4-2" class="pilcrow">¶</a></p>
+<p id="section-4-3">The following is a non-normative example of a invocable URL pointing to a credential offer offered by the OpenID Provider <code>issuer.example.com</code><a href="#section-4-3" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-4-4">
 <pre>openid://offer?https://issuer.example.com/.well-known/openid-configuration#/credential_offers[0]
-</pre><a href="#section-4-3" class="pilcrow">¶</a>
+</pre><a href="#section-4-4" class="pilcrow">¶</a>
 </div>
 </section>
 </div>

--- a/index.html
+++ b/index.html
@@ -1088,7 +1088,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">client-bound-end-user-assertion</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-05-17" class="published">17 May 2020</time>
+<time datetime="2020-05-25" class="published">25 May 2020</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1149,6 +1149,12 @@ tr:nth-child(2n+1) > td {
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.5">
                 <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-requesting-a-credential-usi" class="xref">Requesting a credential using the credential request parameter</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.6">
+                <p id="section-toc.1-1.2.2.6.1"><a href="#section-2.6" class="xref">2.6</a>.  <a href="#name-usage-of-decentralized-iden" class="xref">Usage of Decentralized Identifiers</a><a href="#section-toc.1-1.2.2.6.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.7">
+                <p id="section-toc.1-1.2.2.7.1"><a href="#section-2.7" class="xref">2.7</a>.  <a href="#name-credential-request-using-a-" class="xref">Credential Request using a Decentralized Identifier</a><a href="#section-toc.1-1.2.2.7.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
@@ -1254,17 +1260,17 @@ tr:nth-child(2n+1) > td {
 <a href="#section-2" class="section-number selfRef">2. </a><a href="#name-credential-request" class="section-name selfRef">Credential Request</a>
       </h2>
 <p id="section-2-1">A credential request is an OpenID Connect authentication request that requests that the End-User be authenticated by the Authorization Server and a credential containing the requested claims about the End-User be issued to the Client.<a href="#section-2-1" class="pilcrow">¶</a></p>
-<p id="section-2-2">The following section outlines how an <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest">OpenID Connect Authentication Request</a> must be extended in order for it to be considered a credential request.<a href="#section-2-2" class="pilcrow">¶</a></p>
+<p id="section-2-2">The following section outlines how an <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest">OpenID Connect Authentication Request</a> must be extended in order for it to be a credential request.<a href="#section-2-2" class="pilcrow">¶</a></p>
 <div id="example">
 <section id="section-2.1">
         <h3 id="name-example">
 <a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-example" class="section-name selfRef">Example</a>
         </h3>
-<p id="section-2.1-1">The credential request follows OpenID Connect 1.0 <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> including the required usage of the <code>request</code> parameter.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+<p id="section-2.1-1">The credential request follows <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> including the required, but modified usage of the <code>request</code> parameter.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
 <p id="section-2.1-2">A non-normative example of the Authorization request.<a href="#section-2.1-2" class="pilcrow">¶</a></p>
 <div class="artwork art-text alignLeft" id="section-2.1-3">
 <pre>https://issuer.example.com/authorize
-?scope=openid%20openid:credential
+?scope=openid%20openid_credential
 &amp;request=&lt;signed-jwt-request-obj&gt;
 </pre><a href="#section-2.1-3" class="pilcrow">¶</a>
 </div>
@@ -1275,7 +1281,13 @@ tr:nth-child(2n+1) > td {
   "aud": "https://issuer.example.com",
   "response_type": "code",
   "client_id": "IAicV0pt9co5nn9D1tUKDCoPQq8BFlGH",
-  "sub": "did:example:123456",
+  "sub_jwk" : {
+    "crv":"secp256k1",
+    "kid":"YkDpvGNsch2lFBf6p8u3",
+    "kty":"EC",
+    "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
+    "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
+  },
   "redirect_uri": "https://client.example.com/callback",
   "credential_format": "w3cvc-jsonld",
   "max_age": 86400,
@@ -1290,6 +1302,7 @@ tr:nth-child(2n+1) > td {
 }
 </pre><a href="#section-2.1-5" class="pilcrow">¶</a>
 </div>
+<p id="section-2.1-6">Where the jwt was signed by the key referenced in the <code>sub_jwk</code> section of the request.<a href="#section-2.1-6" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="request-parameters">
@@ -1301,19 +1314,19 @@ tr:nth-child(2n+1) > td {
 <dl class="dlParallel" id="section-2.2-2">
           <dt id="section-2.2-2.1">scope</dt>
 <dd id="section-2.2-2.2">
-            <p id="section-2.2-2.2.1">REQUIRED. A credential request MUST contain the <code>openid:credential</code> scope value in the second position directly after the <code>openid</code> scope.<a href="#section-2.2-2.2.1" class="pilcrow">¶</a></p>
+            <p id="section-2.2-2.2.1">REQUIRED. A credential request MUST contain the <code>openid_credential</code> scope value in the second position directly after the <code>openid</code> scope.<a href="#section-2.2-2.2.1" class="pilcrow">¶</a></p>
 </dd>
-<dt id="section-2.2-2.3">response_type</dt>
+<dt id="section-2.2-2.3">credential_format</dt>
 <dd id="section-2.2-2.4">
-            <p id="section-2.2-2.4.1">REQUIRED. OAuth 2.0 Response Type value that determines the authorization processing flow to be used, including what parameters are returned from the endpoints used. In a credential request this value MUST be set to <code>code</code>, no other values are to be supported.<a href="#section-2.2-2.4.1" class="pilcrow">¶</a></p>
+            <p id="section-2.2-2.4.1">REQUIRED. Determines the format of the credential returned at the end of the flow, values supported by the OpenID Provider are advertised in their openid-configuration metadata, under the <code>credential_formats_supported</code> attribute.<a href="#section-2.2-2.4.1" class="pilcrow">¶</a></p>
 </dd>
-<dt id="section-2.2-2.5">credential_format</dt>
+<dt id="section-2.2-2.5">sub_jwk</dt>
 <dd id="section-2.2-2.6">
-            <p id="section-2.2-2.6.1">REQUIRED. Determines the format of the credential returned at the end of the flow, values supported by the OpenID Provider are advertised in their openid-configuration metadata, under the <code>credential_formats_supported</code> attribute.<a href="#section-2.2-2.6.1" class="pilcrow">¶</a></p>
+            <p id="section-2.2-2.6.1">REQUIRED. Defines the key material the client is requesting the credential to be bound to and the key responsible for signing the request object. Value is a JSON Object that is a valid <a href="https://tools.ietf.org/html/rfc7517">JWK</a>.<a href="#section-2.2-2.6.1" class="pilcrow">¶</a></p>
 </dd>
-<dt id="section-2.2-2.7">sub</dt>
+<dt id="section-2.2-2.7">did</dt>
 <dd id="section-2.2-2.8">
-            <p id="section-2.2-2.8.1">REQUIRED. Defines the identifier the Client is requesting that the subject be referred to as, in the resulting obtained credential.<a href="#section-2.2-2.8.1" class="pilcrow">¶</a></p>
+            <p id="section-2.2-2.8.1">OPTIONAL. Defines the relationship between the key material the client is requesting the credential to be bound to and a <a href="https://w3c.github.io/did-core/">decentralized identifier</a>. Processing of this value requires the OpenID Provider to support the resolution of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a> which is advertised in their openid-configuration metadata, under the <code>dids_supported</code> attribute. The value of this field MUST be a valid <a href="https://w3c.github.io/did-core/">decentralized identifier</a>.<a href="#section-2.2-2.8.1" class="pilcrow">¶</a></p>
 </dd>
 </dl>
 </section>
@@ -1323,13 +1336,13 @@ tr:nth-child(2n+1) > td {
         <h3 id="name-request-parameter">
 <a href="#section-2.3" class="section-number selfRef">2.3. </a><a href="#name-request-parameter" class="section-name selfRef">Request Parameter</a>
         </h3>
-<p id="section-2.3-1">Usage of the <code>request</code> parameter as defined in section <a href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">5.5</a> of OpenID Connect core is REQUIRED in a credential request.<a href="#section-2.3-1" class="pilcrow">¶</a></p>
-<p id="section-2.3-2">The value of the <code>request</code> parameter MUST either be a valid JWT or JWE whose claims are the credential request parameters.<a href="#section-2.3-2" class="pilcrow">¶</a></p>
-<p id="section-2.3-3">Unsigned plaintext Request Objects, containing <code>none</code> in the <code>alg</code> value of the JOSE header MUST not be supported.<a href="#section-2.3-3" class="pilcrow">¶</a></p>
-<p id="section-2.3-4">The Request Object MAY also be encrypted using <a href="https://tools.ietf.org/html/rfc7516">JWE</a>, however the inner payload MUST be a valid <a href="https://tools.ietf.org/html/rfc7519">JWT</a> signed by the Client who created the request.<a href="#section-2.3-4" class="pilcrow">¶</a></p>
-<p id="section-2.3-5">Public private key pairs are used by a requesting Client to establish a means of binding to the resulting credential. A Client making a credential request to an OpenID Provider must prove control over this binding mechanism during the request, this is accomplished through the use of a <a href="https://openid.net/specs/openid-connect-core-1_0.html#SignedRequestObject">signed request</a> defined in OpenID Connect Core.<a href="#section-2.3-5" class="pilcrow">¶</a></p>
-<p id="section-2.3-6">To bind the credential request to the Client making the request, the Request Object MUST be signed by the Client using a public private key pair the Client is in possession of.<a href="#section-2.3-6" class="pilcrow">¶</a></p>
-<p id="section-2.3-7">If the Request Object signing validation fails or is missing, the OpenID Connect Provider MUST respond to the request with the Error Response parameter, <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthError">section 3.1.2.6.</a> with Error code: <code>invalid_request_object</code>.<a href="#section-2.3-7" class="pilcrow">¶</a></p>
+<p id="section-2.3-1">Public private key pairs are used by a requesting Client to establish a means of binding to the resulting credential. A Client making a credential request to an OpenID Provider must prove control over this binding mechanism during the request, this is accomplished through the modified usage of a <a href="https://openid.net/specs/openid-connect-core-1_0.html#SignedRequestObject">signed request</a> defined in OpenID Connect Core.<a href="#section-2.3-1" class="pilcrow">¶</a></p>
+<p id="section-2.3-2">Usage of the <code>request</code> parameter as defined in section <a href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">5.5</a> of OpenID Connect core is REQUIRED in a credential request.<a href="#section-2.3-2" class="pilcrow">¶</a></p>
+<p id="section-2.3-3">The value of the <code>request</code> parameter MUST either be a valid <a href="https://tools.ietf.org/html/rfc7519">JWT</a> or <a href="https://tools.ietf.org/html/rfc7516">JWE</a> whose claims are the credential request parameters, however the inner payload MUST be a valid <a href="https://tools.ietf.org/html/rfc7519">JWT</a> signed by the Client who created the request.<a href="#section-2.3-3" class="pilcrow">¶</a></p>
+<p id="section-2.3-4">The key used to sign the request object MUST validate to that featured in the <code>sub_jwk</code> parameter of the request.<a href="#section-2.3-4" class="pilcrow">¶</a></p>
+<p id="section-2.3-5">Unsigned plaintext Request Objects, containing <code>none</code> in the <code>alg</code> value of the JOSE header MUST not be supported.<a href="#section-2.3-5" class="pilcrow">¶</a></p>
+<p id="section-2.3-6">If the Request Object signing validation fails or is missing, the OpenID Connect Provider MUST respond to the request with the Error Response parameter, <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthError">section 3.1.2.6.</a> with Error code: <code>invalid_request_object</code>.<a href="#section-2.3-6" class="pilcrow">¶</a></p>
+<p id="section-2.3-7">If the <code>did</code> value is present in the request and the OpenID Provider does not support the usage of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a> the value should be ignored.<a href="#section-2.3-7" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="response-types">
@@ -1337,9 +1350,8 @@ tr:nth-child(2n+1) > td {
         <h3 id="name-response-types">
 <a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-response-types" class="section-name selfRef">Response Types</a>
         </h3>
-<p id="section-2.4-1">A credential request flow MUST use the <a href="https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps">authorization code flow</a> as defined in OpenID Connect core.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
-<p id="section-2.4-2">Given that a credential request flow, results in a credential that MUST be retrieved from the Token Endpoint, the <code>response_type=code</code> parameter MUST be used. Additional <code>response_types</code> in a "hybrid" flow MAY be used; <code>token</code> and <code>id_token</code>; however, this is NOT recommended if these are to contain personally identifiable information about the subject.<a href="#section-2.4-2" class="pilcrow">¶</a></p>
-<p id="section-2.4-3">For mobile applications and SPA's it is RECOMMENDED to follow the use of the [Proof Key Code Exchange (PKCE) by OAuth Clients <code>@!RFC7636</code> protocol.<a href="#section-2.4-3" class="pilcrow">¶</a></p>
+<p id="section-2.4-1">It is RECOMMENDED that a credential request flow use the <a href="https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps">authorization code flow</a> as defined in OpenID Connect core.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
+<p id="section-2.4-2">For instances where <a href="https://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth">implicit flow</a> is used, the <code>response_type</code> of <code>credential</code> SHOULD be used.<a href="#section-2.4-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="requesting-a-credential-using-the-credential-request-parameter">
@@ -1354,8 +1366,14 @@ tr:nth-child(2n+1) > td {
   "aud": "https://issuer.example.com",
   "response_type": "code",
   "client_id": "IAicV0pt9co5nn9D1tUKDCoPQq8BFlGH",
-  "sub": "did:example:123456",
-  "redirect_uri": "https://Client.example.com/callback",
+  "sub_jwk" : {
+    "crv":"secp256k1",
+    "kid":"YkDpvGNsch2lFBf6p8u3",
+    "kty":"EC",
+    "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
+    "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
+  },
+  "redirect_uri": "https://client.example.com/callback",
   "credential_format": "w3cvc-jsonld",
   "max_age": 86400,
   "claims":
@@ -1371,6 +1389,67 @@ tr:nth-child(2n+1) > td {
 </div>
 </section>
 </div>
+<div id="usage-of-decentralized-identifiers">
+<section id="section-2.6">
+        <h3 id="name-usage-of-decentralized-iden">
+<a href="#section-2.6" class="section-number selfRef">2.6. </a><a href="#name-usage-of-decentralized-iden" class="section-name selfRef">Usage of Decentralized Identifiers</a>
+        </h3>
+<p id="section-2.6-1"><a href="https://w3c.github.io/did-core/">Decentralized identifiers</a> are a resolvable identifier to a set of statements about the [did subject]() including a set of cryptographic material (e.g public keys). Using this cryptographic material, a <a href="https://w3c.github.io/did-core/">decentralized identifier</a> can be used as an authenticatable identifier in a credential.<a href="#section-2.6-1" class="pilcrow">¶</a></p>
+<p id="section-2.6-2">The below section highlights how a client construct a credential request to obtain a credential that is bound to the client via the usage of a <a href="https://w3c.github.io/did-core/">decentralized identifier</a>.<a href="#section-2.6-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="credential-request-using-a-decentralized-identifier">
+<section id="section-2.7">
+        <h3 id="name-credential-request-using-a-">
+<a href="#section-2.7" class="section-number selfRef">2.7. </a><a href="#name-credential-request-using-a-" class="section-name selfRef">Credential Request using a Decentralized Identifier</a>
+        </h3>
+<p id="section-2.7-1">A Client can request in the credential issuance flow, that the resulting credential be bound to the client through the usage of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a> by using the <code>did</code> field.<a href="#section-2.7-1" class="pilcrow">¶</a></p>
+<p id="section-2.7-2">An OpenID Provider processing a credential request featuring a <a href="https://w3c.github.io/did-core/">decentralized identifier</a> MUST follow the following additional steps to validate the request.<a href="#section-2.7-2" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-2.7-3">
+          <li id="section-2.7-3.1">
+            <p id="section-2.7-3.1.1">Validate the value in the <code>did</code> field is a valid <a href="https://w3c.github.io/did-core/">decentralized identifier</a><a href="#section-2.7-3.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.7-3.2">
+            <p id="section-2.7-3.2.1">Resolve this the <code>did</code> value to a [did document]().<a href="#section-2.7-3.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-2.7-3.3">
+            <p id="section-2.7-3.3.1">Validate that the key in the <code>sub_jwk</code> field of the request appears in the <code>publicKey</code> section of the [DID Document]().<a href="#section-2.7-3.3.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+<p id="section-2.7-4">If any of the steps fail then the OpenID Provider MUST respond to the request with the Error Response parameter, <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthError">section 3.1.2.6.</a> with Error code: <code>invalid_did</code>.<a href="#section-2.7-4" class="pilcrow">¶</a></p>
+<p id="section-2.7-5">A Client prior to submitting a credential request SHOULD validate that the OpenID Provider supports the resolution of decentralized identifiers by retrieving their openid-configuration metadata to check if an attribute of <code>dids_supported</code> has a value of <code>true</code>.<a href="#section-2.7-5" class="pilcrow">¶</a></p>
+<p id="section-2.7-6">The Client SHOULD also validate that the OpenID Provider supports the <a href="https://w3c-ccg.github.io/did-method-registry/">did method</a> to be used in the request by retrieving their openid-configuration metadata to check if an attribute of <code>did_methods_supported</code> contains the required did method.<a href="#section-2.7-6" class="pilcrow">¶</a></p>
+<p id="section-2.7-7">The following is a non-normative example of requesting the issuance of a credential that uses a decentralized identifier.<a href="#section-2.7-7" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-2.7-8">
+<pre>{
+  "iss": "IAicV0pt9co5nn9D1tUKDCoPQq8BFlGH",
+  "aud": "https://issuer.example.com",
+  "response_type": "code",
+  "client_id": "IAicV0pt9co5nn9D1tUKDCoPQq8BFlGH",
+  "sub_jwk" : {
+    "crv":"secp256k1",
+    "kid":"YkDpvGNsch2lFBf6p8u3",
+    "kty":"EC",
+    "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
+    "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
+  },
+  "did": "did:example:1234",
+  "redirect_uri": "https://Client.example.com/callback",
+  "credential_format": "w3cvc-jsonld",
+  "max_age": 86400,
+  "claims":
+  {
+    "credential": {
+      "given_name": {"essential": true},
+      "last_name": {"essential": true},
+      "https://www.w3.org/2018/credentials/examples/v1/degree": {"essential": true}
+    },
+  }
+}
+</pre><a href="#section-2.7-8" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
 </section>
 </div>
 <div id="credential-response">
@@ -1383,7 +1462,7 @@ tr:nth-child(2n+1) > td {
         <h3 id="name-credential">
 <a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-credential" class="section-name selfRef">Credential</a>
         </h3>
-<p id="section-3.1-1">A Credential is a Client bound assertion describing the End-User authenticated in an OpenID flow. Formats of the Credential can vary, examples include JSON-LD or JWT based Credentials, the OpenID provider should make the supported credential formats available at their openid-configuration meta-data endpoint.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
+<p id="section-3.1-1">A Credential is a Client bound assertion describing the End-User authenticated in an OpenID flow. Formats of the Credential can vary, examples include JSON-LD or JWT based Credentials, the OpenID provider SHOULD make the supported credential formats available at their openid-configuration meta-data endpoint.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
 <p id="section-3.1-2">The following is a non-normative example of a Credential issued as a <a href="https://www.w3.org/TR/vc-data-model/">W3C Verifiable Credential 1.0</a> compliant format in JSON-LD.<a href="#section-3.1-2" class="pilcrow">¶</a></p>
 <div class="artwork art-text alignLeft" id="section-3.1-3">
 <pre>{
@@ -1497,10 +1576,24 @@ tr:nth-child(2n+1) > td {
 <dd id="section-5-2.6">
           <p id="section-5-2.6.1">A JSON array of objects, each of which describing a group of related claims that can be referred to when interacting with the OpenID provider.<a href="#section-5-2.6.1" class="pilcrow">¶</a></p>
 </dd>
+<dt id="section-5-2.7"><code>dids_supported</code></dt>
+<dd id="section-5-2.8">
+          <p id="section-5-2.8.1">Boolean value indicating that the OpenID provider supports the resolution of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a>.<a href="#section-5-2.8.1" class="pilcrow">¶</a></p>
+</dd>
+<dt id="section-5-2.9"><code>did_methods_supported</code></dt>
+<dd id="section-5-2.10">
+          <p id="section-5-2.10.1">A JSON array of strings representing <a href="https://w3c-ccg.github.io/did-method-registry/">Decentralized Identifier Methods</a> that the OpenID provider supports resolution of<a href="#section-5-2.10.1" class="pilcrow">¶</a></p>
+</dd>
 </dl>
 <p id="section-5-3">The following is a non-normative example of the relevant entries in the openid-configuration meta data for an OpenID Provider supporting the credential issuance flow<a href="#section-5-3" class="pilcrow">¶</a></p>
 <div class="artwork art-text alignLeft" id="section-5-4">
 <pre>{
+  "dids_supported": true,
+  "did_methods_supported": [
+    "ion",
+    "element",
+    "key"
+  ],
   "credential_supported": true,
   "credential_formats_supported": [
     "w3cvc-jsonld",

--- a/spec.md
+++ b/spec.md
@@ -213,7 +213,7 @@ A non-normative example of a payload of a signed Request Object.
 
 ## Usage of Decentralized Identifiers
 
-[Decentralized identifiers](https://w3c.github.io/did-core/) are a resolvable identifier to a set of statements about the [did subject]() including a set of cryptographic material (e.g public keys). Using this cryptographic material, a [decentralized identifier](https://w3c.github.io/did-core/) can be used as an authenticatable identifier in a credential. 
+[Decentralized identifiers](https://w3c.github.io/did-core/) are a resolvable identifier to a set of statements about the [did subject](https://w3c.github.io/did-core/#dfn-did-subjects) including a set of cryptographic material (e.g public keys). Using this cryptographic material, a [decentralized identifier](https://w3c.github.io/did-core/) can be used as an authenticatable identifier in a credential. 
 
 The below section highlights how a client construct a credential request to obtain a credential that is bound to the client via the usage of a [decentralized identifier](https://w3c.github.io/did-core/).
 
@@ -347,6 +347,8 @@ The following is a non-normative example of a JSON-LD based Credential.
 ```
 
 # Credential Offer
+
+**NOTE this section is still a W.I.P**
 
 The openid-configuration for an OpenID provider is used to communicate to Clients what capabilities the provider supports, including whether or not it supports the credential issuance flow. Sometime it is desirable to be able to embedded a link to an offer that is invocable by supported Clients.
 

--- a/spec.md
+++ b/spec.md
@@ -97,17 +97,17 @@ These steps are illustrated in the following diagram:
 
 A credential request is an OpenID Connect authentication request that requests that the End-User be authenticated by the Authorization Server and a credential containing the requested claims about the End-User be issued to the Client.
 
-The following section outlines how an [OpenID Connect Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) must be extended in order for it to be considered a credential request.
+The following section outlines how an [OpenID Connect Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) must be extended in order for it to be a credential request.
 
 ## Example
 
-The credential request follows OpenID Connect 1.0 [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) including the required usage of the `request` parameter.
+The credential request follows [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) including the required, but modified usage of the `request` parameter.
 
 A non-normative example of the Authorization request.
 
 ```
 https://issuer.example.com/authorize
-?scope=openid%20openid:credential
+?scope=openid%20openid_credential
 &request=<signed-jwt-request-obj>
 ```
 
@@ -119,7 +119,13 @@ Where the decoded payload of the request parameter is as follows
   "aud": "https://issuer.example.com",
   "response_type": "code",
   "client_id": "IAicV0pt9co5nn9D1tUKDCoPQq8BFlGH",
-  "sub": "did:example:123456",
+  "sub_jwk" : {
+    "crv":"secp256k1",
+    "kid":"YkDpvGNsch2lFBf6p8u3",
+    "kty":"EC",
+    "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
+    "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
+  },
   "redirect_uri": "https://client.example.com/callback",
   "credential_format": "w3cvc-jsonld",
   "max_age": 86400,
@@ -134,45 +140,45 @@ Where the decoded payload of the request parameter is as follows
 }
 ```
 
+Where the jwt was signed by the key referenced in the `sub_jwk` section of the request.
+
 ## Request Parameters
 
 A credential request uses the OpenID and OAuth2.0 request parameters as outlined in section [3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) of OpenID Connect core, except for the following additional constraints.
 
 scope
-: REQUIRED. A credential request MUST contain the `openid:credential` scope value in the second position directly after the `openid` scope.
-
-response_type
-: REQUIRED. OAuth 2.0 Response Type value that determines the authorization processing flow to be used, including what parameters are returned from the endpoints used. In a credential request this value MUST be set to `code`, no other values are to be supported.
+: REQUIRED. A credential request MUST contain the `openid_credential` scope value in the second position directly after the `openid` scope.
 
 credential_format
 : REQUIRED. Determines the format of the credential returned at the end of the flow, values supported by the OpenID Provider are advertised in their openid-configuration metadata, under the `credential_formats_supported` attribute.
 
-sub
-: REQUIRED. Defines the identifier the Client is requesting that the subject be referred to as, in the resulting obtained credential.
+sub_jwk
+: REQUIRED. Defines the key material the client is requesting the credential to be bound to and the key responsible for signing the request object. Value is a JSON Object that is a valid [JWK](https://tools.ietf.org/html/rfc7517).
+
+did
+: OPTIONAL. Defines the relationship between the key material the client is requesting the credential to be bound to and a [decentralized identifier](https://w3c.github.io/did-core/). Processing of this value requires the OpenID Provider to support the resolution of [decentralized identifiers](https://w3c.github.io/did-core/) which is advertised in their openid-configuration metadata, under the `dids_supported` attribute. The value of this field MUST be a valid [decentralized identifier](https://w3c.github.io/did-core/).
 
 ## Request Parameter
 
+Public private key pairs are used by a requesting Client to establish a means of binding to the resulting credential. A Client making a credential request to an OpenID Provider must prove control over this binding mechanism during the request, this is accomplished through the modified usage of a [signed request](https://openid.net/specs/openid-connect-core-1_0.html#SignedRequestObject) defined in OpenID Connect Core.
+
 Usage of the `request` parameter as defined in section [5.5](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter) of OpenID Connect core is REQUIRED in a credential request.
 
-The value of the `request` parameter MUST either be a valid [JWT](https://tools.ietf.org/html/rfc7519) or [JWE](https://tools.ietf.org/html/rfc7516) whose claims are the credential request parameters.
+The value of the `request` parameter MUST either be a valid [JWT](https://tools.ietf.org/html/rfc7519) or [JWE](https://tools.ietf.org/html/rfc7516) whose claims are the credential request parameters, however the inner payload MUST be a valid [JWT](https://tools.ietf.org/html/rfc7519) signed by the Client who created the request.
+
+The key used to sign the request object MUST validate to that featured in the `sub_jwk` parameter of the request.
 
 Unsigned plaintext Request Objects, containing `none` in the `alg` value of the JOSE header MUST not be supported.
 
-The Request Object MAY also be encrypted using [JWE](https://tools.ietf.org/html/rfc7516), however the inner payload MUST be a valid [JWT](https://tools.ietf.org/html/rfc7519) signed by the Client who created the request.
-
-Public private key pairs are used by a requesting Client to establish a means of binding to the resulting credential. A Client making a credential request to an OpenID Provider must prove control over this binding mechanism during the request, this is accomplished through the use of a [signed request](https://openid.net/specs/openid-connect-core-1_0.html#SignedRequestObject) defined in OpenID Connect Core.
-
-To bind the credential request to the Client making the request, the Request Object MUST be signed by the Client using a public private key pair the Client is in possession of.
-
 If the Request Object signing validation fails or is missing, the OpenID Connect Provider MUST respond to the request with the Error Response parameter, [section 3.1.2.6.](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) with Error code: `invalid_request_object`.
+
+If the `did` value is present in the request and the OpenID Provider does not support the usage of [decentralized identifiers](https://w3c.github.io/did-core/) the value should be ignored.
 
 ## Response Types
 
-A credential request flow MUST use the [authorization code flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps) as defined in OpenID Connect core.
+It is RECOMMENDED that a credential request flow use the [authorization code flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps) as defined in OpenID Connect core.
 
-Given that a credential request flow, results in a credential that MUST be retrieved from the Token Endpoint, the `response_type=code` parameter MUST be used. Additional `response_types` in a "hybrid" flow MAY be used; `token` and `id_token`; however, this is NOT recommended if these are to contain personally identifiable information about the subject.
-
-For mobile applications and SPA's it is RECOMMENDED to follow the use of the [Proof Key Code Exchange (PKCE) by OAuth Clients `@!RFC7636` protocol.
+For instances where [implicit flow](https://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth) is used, the `response_type` of `credential` SHOULD be used.
 
 ## Requesting a credential using the credential request parameter
 
@@ -184,7 +190,65 @@ A non-normative example of a payload of a signed Request Object.
   "aud": "https://issuer.example.com",
   "response_type": "code",
   "client_id": "IAicV0pt9co5nn9D1tUKDCoPQq8BFlGH",
-  "sub": "did:example:123456",
+  "sub_jwk" : {
+    "crv":"secp256k1",
+    "kid":"YkDpvGNsch2lFBf6p8u3",
+    "kty":"EC",
+    "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
+    "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
+  },
+  "redirect_uri": "https://client.example.com/callback",
+  "credential_format": "w3cvc-jsonld",
+  "max_age": 86400,
+  "claims":
+  {
+    "credential": {
+      "given_name": {"essential": true},
+      "last_name": {"essential": true},
+      "https://www.w3.org/2018/credentials/examples/v1/degree": {"essential": true}
+    },
+  }
+}
+```
+
+## Usage of Decentralized Identifiers
+
+[Decentralized identifiers](https://w3c.github.io/did-core/) are a resolvable identifier to a set of statements about the [did subject]() including a set of cryptographic material (e.g public keys). Using this cryptographic material, a [decentralized identifier](https://w3c.github.io/did-core/) can be used as an authenticatable identifier in a credential. 
+
+The below section highlights how a client construct a credential request to obtain a credential that is bound to the client via the usage of a [decentralized identifier](https://w3c.github.io/did-core/).
+
+## Credential Request using a Decentralized Identifier
+
+A Client can request in the credential issuance flow, that the resulting credential be bound to the client through the usage of [decentralized identifiers](https://w3c.github.io/did-core/) by using the `did` field.
+
+An OpenID Provider processing a credential request featuring a [decentralized identifier](https://w3c.github.io/did-core/) MUST follow the following additional steps to validate the request.
+
+1. Validate the value in the `did` field is a valid [decentralized identifier](https://w3c.github.io/did-core/)
+2. Resolve this the `did` value to a [did document]().
+3. Validate that the key in the `sub_jwk` field of the request appears in the `publicKey` section of the [DID Document]().
+
+If any of the steps fail then the OpenID Provider MUST respond to the request with the Error Response parameter, [section 3.1.2.6.](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) with Error code: `invalid_did`.
+
+A Client prior to submitting a credential request SHOULD validate that the OpenID Provider supports the resolution of decentralized identifiers by retrieving their openid-configuration metadata to check if an attribute of `dids_supported` has a value of `true`.
+
+The Client SHOULD also validate that the OpenID Provider supports the [did method](https://w3c-ccg.github.io/did-method-registry/) to be used in the request by retrieving their openid-configuration metadata to check if an attribute of `did_methods_supported` contains the required did method.
+
+The following is a non-normative example of requesting the issuance of a credential that uses a decentralized identifier.
+
+```
+{
+  "iss": "IAicV0pt9co5nn9D1tUKDCoPQq8BFlGH",
+  "aud": "https://issuer.example.com",
+  "response_type": "code",
+  "client_id": "IAicV0pt9co5nn9D1tUKDCoPQq8BFlGH",
+  "sub_jwk" : {
+    "crv":"secp256k1",
+    "kid":"YkDpvGNsch2lFBf6p8u3",
+    "kty":"EC",
+    "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
+    "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
+  },
+  "did": "did:example:1234",
   "redirect_uri": "https://Client.example.com/callback",
   "credential_format": "w3cvc-jsonld",
   "max_age": 86400,
@@ -203,7 +267,7 @@ A non-normative example of a payload of a signed Request Object.
 
 ## Credential
 
-A Credential is a Client bound assertion describing the End-User authenticated in an OpenID flow. Formats of the Credential can vary, examples include JSON-LD or JWT based Credentials, the OpenID provider should make the supported credential formats available at their openid-configuration meta-data endpoint.
+A Credential is a Client bound assertion describing the End-User authenticated in an OpenID flow. Formats of the Credential can vary, examples include JSON-LD or JWT based Credentials, the OpenID provider SHOULD make the supported credential formats available at their openid-configuration meta-data endpoint.
 
 The following is a non-normative example of a Credential issued as a [W3C Verifiable Credential 1.0](https://www.w3.org/TR/vc-data-model/) compliant format in JSON-LD.
 
@@ -305,10 +369,22 @@ An OpenID provider can use the following meta-data elements to advertise its sup
 `credential_offers`
 : A JSON array of objects, each of which describing a group of related claims that can be referred to when interacting with the OpenID provider.
 
+`dids_supported`
+: Boolean value indicating that the OpenID provider supports the resolution of [decentralized identifiers](https://w3c.github.io/did-core/).
+
+`did_methods_supported`
+: A JSON array of strings representing [Decentralized Identifier Methods](https://w3c-ccg.github.io/did-method-registry/) that the OpenID provider supports resolution of
+
 The following is a non-normative example of the relevant entries in the openid-configuration meta data for an OpenID Provider supporting the credential issuance flow
 
 ```
 {
+  "dids_supported": true,
+  "did_methods_supported": [
+    "ion",
+    "element",
+    "key"
+  ],
   "credential_supported": true,
   "credential_formats_supported": [
     "w3cvc-jsonld",
@@ -326,3 +402,4 @@ The following is a non-normative example of the relevant entries in the openid-c
   ]
 }
 ```
+


### PR DESCRIPTION
- Change the `openid:credential` scope to `openid_credential`
- Relax the constraint around having to use authorization code flow
- Add a seperate section on how decentralized identifiers can be used within the protocol
- Change the approach to how the key material binding is performed, the key now doesn't need to be registered with the OP prior instead can be generated ephemerally