### PR TITLE
feat: add reference to claims request syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -1088,7 +1088,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">client-bound-end-user-assertion</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-06-02" class="published">2 June 2020</time>
+<time datetime="2020-06-03" class="published">3 June 2020</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1268,7 +1268,7 @@ tr:nth-child(2n+1) > td {
         <h3 id="name-example">
 <a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-example" class="section-name selfRef">Example</a>
         </h3>
-<p id="section-2.1-1">The credential request follows <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> including the required, but modified usage of the <code>request</code> parameter.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+<p id="section-2.1-1">The credential request follows <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> including the required, but modified usage of the <code>request</code> parameter. The syntax around requesting claims to feature in the resulting credential is defined in <a href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">Section 5.5 of OpenID Connect Core 1.0</a> with the addition of the new top level member of <code>credential</code>.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
 <p id="section-2.1-2">A non-normative example of the Authorization request.<a href="#section-2.1-2" class="pilcrow">¶</a></p>
 <div class="artwork art-text alignLeft" id="section-2.1-3">
 <pre>https://issuer.example.com/authorize

--- a/spec.md
+++ b/spec.md
@@ -101,7 +101,7 @@ The following section outlines how an [OpenID Connect Authentication Request](ht
 
 ## Example
 
-The credential request follows [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) including the required, but modified usage of the `request` parameter.
+The credential request follows [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) including the required, but modified usage of the `request` parameter. The syntax around requesting claims to feature in the resulting credential is defined in [Section 5.5 of OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter) with the addition of the new top level member of `credential`.
 
 A non-normative example of the Authorization request.
 


### PR DESCRIPTION
This PR adds a reference to the claims request syntax, to clarify the source of this format is not bespoke to this spec