### PR TITLE
refactor: rename spec to credential provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# OpenID Client Bound End-User Assertion
+# OpenID Connect Credential Provider
 
 [Latest Draft](https://mattrglobal.github.io/oidc-client-bound-assertions-spec/)
 
-This repository is the home to the draft specification to extend OpenID Connect to support client bound end-user assertions that enable new approaches around federated sharing of identity information.
+This repository is the home to the draft specification to extend an OpenID Connect Provider to support the issuance of credentials which in turn enable new approaches around federated sharing of identity information.
 
 ## Contributing
 

--- a/index.html
+++ b/index.html
@@ -4,17 +4,17 @@
 <meta charset="utf-8">
 <meta content="Common,Latin" name="scripts">
 <meta content="initial-scale=1.0" name="viewport">
-<title>Client Bound End-User Assertion</title>
+<title>OpenID Connect Credential Provider</title>
 <meta content="Tobias Looker" name="author">
 <meta content="John Thompson" name="author">
 <meta content="
-       OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables Clients to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User. 
-       Typically the format of the assertion obtained about the End-User in the OpenID Connect protocol, known as the  id_token  or user assertion, is said to be bearer in nature, meaning it features no authenticatable binding to the Client that requested it. Because of this limitation, OpenID Connect is constrained to an architecture where relying parties must be in direct contact with the issuers/authorities of obtained user assertions in order to trust their presentations. 
-       This specification defines how the OpenID Connect protocol can be extended so that a Client can obtain an assertion about the End-User which is bound to the Client in an authenticatable manner based on public/private key cryptography. This feature then enables the Client to onward present the obtained assertion to other relying parties whilst authenticating the established binding to the assertion. 
+       OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables relying parties to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User. 
+       In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as the  NASCAR problem  and  relying party tracking . 
+       This specification defines how an OpenID provider can be extended beyond being the provider of simple identity assertions into being the provider of credentials. 
     " name="description">
 <meta content="xml2rfc 2.40.1" name="generator">
-<meta content="client-bound-end-user-assertion-01" name="ietf.draft">
-<link href="./client-bound-end-user-assertion-01.xml" rel="alternate" type="application/rfc+xml">
+<meta content="openid-credential-provider-01" name="ietf.draft">
+<link href="./openid-credential-provider-01.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1070,7 +1070,7 @@ tr:nth-child(2n+1) > td {
 <table class="ears">
 <thead><tr>
 <td class="left"></td>
-<td class="center">Client Bound End-User Assertion</td>
+<td class="center">OpenID Connect Credential Provider</td>
 <td class="right">July 2020</td>
 </tr></thead>
 <tfoot><tr>
@@ -1085,10 +1085,10 @@ tr:nth-child(2n+1) > td {
 <dt class="label-workgroup">Workgroup:</dt>
 <dd class="workgroup">none</dd>
 <dt class="label-individual-draft">Individual-Draft:</dt>
-<dd class="individual-draft">client-bound-end-user-assertion-01</dd>
+<dd class="individual-draft">openid-credential-provider-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-07-29" class="published">29 July 2020</time>
+<time datetime="2020-07-31" class="published">31 July 2020</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1105,12 +1105,12 @@ tr:nth-child(2n+1) > td {
 </dd>
 </dl>
 </div>
-<h1 id="title">Client Bound End-User Assertion</h1>
+<h1 id="title">OpenID Connect Credential Provider</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
-<p id="section-abstract-1">OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables Clients to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
-<p id="section-abstract-2">Typically the format of the assertion obtained about the End-User in the OpenID Connect protocol, known as the <code>id_token</code> or user assertion, is said to be bearer in nature, meaning it features no authenticatable binding to the Client that requested it. Because of this limitation, OpenID Connect is constrained to an architecture where relying parties must be in direct contact with the issuers/authorities of obtained user assertions in order to trust their presentations.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
-<p id="section-abstract-3">This specification defines how the OpenID Connect protocol can be extended so that a Client can obtain an assertion about the End-User which is bound to the Client in an authenticatable manner based on public/private key cryptography. This feature then enables the Client to onward present the obtained assertion to other relying parties whilst authenticating the established binding to the assertion.<a href="#section-abstract-3" class="pilcrow">¶</a></p>
+<p id="section-abstract-1">OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables relying parties to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+<p id="section-abstract-2">In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as the <a href="https://indieweb.org/NASCAR_problem">NASCAR problem</a> and <a href="https://github.com/WICG/WebID#the-rp-tracking-problem">relying party tracking</a>.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
+<p id="section-abstract-3">This specification defines how an OpenID provider can be extended beyond being the provider of simple identity assertions into being the provider of credentials.<a href="#section-abstract-3" class="pilcrow">¶</a></p>
 </section>
 <div id="toc">
 <section id="section-toc.1">
@@ -1186,9 +1186,10 @@ tr:nth-child(2n+1) > td {
       <h2 id="name-introduction">
 <a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
       </h2>
-<p id="section-1-1">OpenID Connect 1.0 <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> is a simple identity layer on top of the OAuth 2.0 <code>@!RFC6749</code> protocol. It enables Clients to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.<a href="#section-1-1" class="pilcrow">¶</a></p>
-<p id="section-1-2">Typically the format of the assertion obtained about the End-User in the OpenID Connect protocol, known as the <code>id_token</code> or user assertion, is said to be bearer in nature, meaning it features no authenticatable binding to the Client that requested it. Because of this limitation, OpenID Connect is constrained to an architecture where relying parties must be in direct contact with the issuers/authorities of obtained user assertions in order to trust their presentations.<a href="#section-1-2" class="pilcrow">¶</a></p>
-<p id="section-1-3">This specification defines how the OpenID Connect protocol can be extended so that a Client can obtain an assertion about the End-User which is bound to the Client in an authenticatable manner based on public/private key cryptography. This feature then enables the Client to onward present the obtained assertion to other relying parties whilst authenticating the established binding to the assertion.<a href="#section-1-3" class="pilcrow">¶</a></p>
+<p id="section-1-1">OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables relying parties to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.<a href="#section-1-1" class="pilcrow">¶</a></p>
+<p id="section-1-2">In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as the <a href="https://indieweb.org/NASCAR_problem">NASCAR problem</a> and <a href="https://github.com/WICG/WebID#the-rp-tracking-problem">relying party tracking</a>.<a href="#section-1-2" class="pilcrow">¶</a></p>
+<p id="section-1-3">Typically the format of the assertion obtained about the End-User in the OpenID Connect protocol, known as the <code>id_token</code> or user assertion, is said to be bearer in nature, meaning it features no authenticatable binding to the Client that requested it. Therefore using this user assertion as a credential is impractical in many instances from a security perspective. Instead what is required for a user assertion to be suitable as a credential, is for it to feature some form of binding to the Client that requested it.<a href="#section-1-3" class="pilcrow">¶</a></p>
+<p id="section-1-4">This specification defines how the OpenID Connect protocol can be extended so that a supporting Client can obtain a credential on-behalf of an End-User. Where a credential is defined as an assertion about the End-User which is bound to the Client in an authenticatable manner based on public/private key cryptography. This feature then enables the Client to onward present the credential to other relying parties whilst authenticating the established binding to the assertion.<a href="#section-1-4" class="pilcrow">¶</a></p>
 <div id="requirements-notation-and-conventions">
 <section id="section-1.1">
         <h3 id="name-requirements-notation-and-c">
@@ -1225,7 +1226,7 @@ tr:nth-child(2n+1) > td {
 <p id="section-1.3-1">This specification extends the OpenID Connect protocol for the purposes of credential issuance.<a href="#section-1.3-1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-1.3-2">
           <li id="section-1.3-2.1">
-            <p id="section-1.3-2.1.1">The Client sends a credential request to the OpenID Provider (OpenID Provider).<a href="#section-1.3-2.1.1" class="pilcrow">¶</a></p>
+            <p id="section-1.3-2.1.1">The Client sends a credential request to the OpenID Provider (OP).<a href="#section-1.3-2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-1.3-2.2">
             <p id="section-1.3-2.2.1">The OpenID Provider authenticates the End-User and obtains authorization.<a href="#section-1.3-2.2.1" class="pilcrow">¶</a></p>
@@ -1252,6 +1253,25 @@ tr:nth-child(2n+1) > td {
 +--------+                                   +----------+
 </pre><a href="#section-1.3-4" class="pilcrow">¶</a>
 </div>
+<p id="section-1.3-5"><strong>Note</strong> - Outside of the scope for this specification is how the client then exercises presentation of this credential with a relying party, however the overall diagram looks like the following.<a href="#section-1.3-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-1.3-6">
+<pre>+---------+                             +--------+                                   +----------+
+|         |--(1) Presentation Request--&gt;|        |                                   |          |
+|         |                             |        |------(2) Credential Request------&gt;|          |
+|         |                             |        |                                   |          |
+|         |                             |        |  +--------+                       |          |
+|         |                             |        |  |        |                       |          |
+| Relying |                             | Client |  |  End-  |&lt;--(3) AuthN &amp; AuthZ--&gt;|    OP    |
+|  Party  |                             |        |  |  User  |                       |          |
+|         |                             |        |  |        |                       |          |
+|         |                             |        |  +--------+                       |          |
+|         |                             |        |                                   |          |
+|         |                             |        |&lt;-----(4) Credential Response------|          |
+|         |&lt;-(5) Presentation Response--|        |                                   |          |
++---------+                             +--------+                                   +----------+
+</pre><a href="#section-1.3-6" class="pilcrow">¶</a>
+</div>
+<p id="section-1.3-7"><strong>Note</strong> - Steps 2-4 (interaction between the client and OP) do not have to occur within the same transaction as steps 1 and 5 (interaction between the relying party and the client)<a href="#section-1.3-7" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>

--- a/scripts/build-html.sh
+++ b/scripts/build-html.sh
@@ -5,4 +5,4 @@ docker run -v `pwd`:/data danielfett/markdown2rfc spec.md
 rm *.xml
 
 # Rename the HTML version for hosting with GH pages
-mv client-bound-end-user-assertion-*.html index.html
+mv openid-credential-provider-*.html index.html

--- a/spec.md
+++ b/spec.md
@@ -1,6 +1,6 @@
 %%%
-title = "Client Bound End-User Assertion"
-abbrev = "Client Bound End-User Assertion"
+title = "OpenID Connect Credential Provider"
+abbrev = "OpenID Connect Credential Provider"
 ipr = "none"
 workgroup = "none"
 keyword = [""]
@@ -8,7 +8,7 @@ keyword = [""]
 
 [seriesInfo]
 name = "Individual-Draft"
-value = "client-bound-end-user-assertion-01"
+value = "openid-credential-provider-01"
 status = "informational"
 
 [[author]]
@@ -32,21 +32,23 @@ email = "john.thompson@mattr.global"
 
 .# Abstract
 
-OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables Clients to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.
+OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables relying parties to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.
 
-Typically the format of the assertion obtained about the End-User in the OpenID Connect protocol, known as the `id_token` or user assertion, is said to be bearer in nature, meaning it features no authenticatable binding to the Client that requested it. Because of this limitation, OpenID Connect is constrained to an architecture where relying parties must be in direct contact with the issuers/authorities of obtained user assertions in order to trust their presentations.
+In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as the [NASCAR problem](https://indieweb.org/NASCAR_problem) and [relying party tracking](https://github.com/WICG/WebID#the-rp-tracking-problem).
 
-This specification defines how the OpenID Connect protocol can be extended so that a Client can obtain an assertion about the End-User which is bound to the Client in an authenticatable manner based on public/private key cryptography. This feature then enables the Client to onward present the obtained assertion to other relying parties whilst authenticating the established binding to the assertion.
+This specification defines how an OpenID provider can be extended beyond being the provider of simple identity assertions into being the provider of credentials.
 
 {mainmatter}
 
 # Introduction {#Introduction}
 
-OpenID Connect 1.0 [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) is a simple identity layer on top of the OAuth 2.0 `@!RFC6749` protocol. It enables Clients to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.
+OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables relying parties to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.
 
-Typically the format of the assertion obtained about the End-User in the OpenID Connect protocol, known as the `id_token` or user assertion, is said to be bearer in nature, meaning it features no authenticatable binding to the Client that requested it. Because of this limitation, OpenID Connect is constrained to an architecture where relying parties must be in direct contact with the issuers/authorities of obtained user assertions in order to trust their presentations.
+In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as the [NASCAR problem](https://indieweb.org/NASCAR_problem) and [relying party tracking](https://github.com/WICG/WebID#the-rp-tracking-problem).
 
-This specification defines how the OpenID Connect protocol can be extended so that a Client can obtain an assertion about the End-User which is bound to the Client in an authenticatable manner based on public/private key cryptography. This feature then enables the Client to onward present the obtained assertion to other relying parties whilst authenticating the established binding to the assertion.
+Typically the format of the assertion obtained about the End-User in the OpenID Connect protocol, known as the `id_token` or user assertion, is said to be bearer in nature, meaning it features no authenticatable binding to the Client that requested it. Therefore using this user assertion as a credential is impractical in many instances from a security perspective. Instead what is required for a user assertion to be suitable as a credential, is for it to feature some form of binding to the Client that requested it.
+
+This specification defines how the OpenID Connect protocol can be extended so that a supporting Client can obtain a credential on-behalf of an End-User. Where a credential is defined as an assertion about the End-User which is bound to the Client in an authenticatable manner based on public/private key cryptography. This feature then enables the Client to onward present the credential to other relying parties whilst authenticating the established binding to the assertion.
 
 ## Requirements Notation and Conventions
 
@@ -70,7 +72,7 @@ Credential Request
 
 This specification extends the OpenID Connect protocol for the purposes of credential issuance.
 
-1. The Client sends a credential request to the OpenID Provider (OpenID Provider).
+1. The Client sends a credential request to the OpenID Provider (OP).
 2. The OpenID Provider authenticates the End-User and obtains authorization.
 3. The OpenID Provider responds with a Credential.
 
@@ -92,6 +94,27 @@ These steps are illustrated in the following diagram:
 |        |                                   |          |
 +--------+                                   +----------+
 ```
+
+**Note** - Outside of the scope for this specification is how the client then exercises presentation of this credential with a relying party, however the overall diagram looks like the following.
+
+```
++---------+                             +--------+                                   +----------+
+|         |--(1) Presentation Request-->|        |                                   |          |
+|         |                             |        |------(2) Credential Request------>|          |
+|         |                             |        |                                   |          |
+|         |                             |        |  +--------+                       |          |
+|         |                             |        |  |        |                       |          |
+| Relying |                             | Client |  |  End-  |<--(3) AuthN & AuthZ-->|    OP    |
+|  Party  |                             |        |  |  User  |                       |          |
+|         |                             |        |  |        |                       |          |
+|         |                             |        |  +--------+                       |          |
+|         |                             |        |                                   |          |
+|         |                             |        |<-----(4) Credential Response------|          |
+|         |<-(5) Presentation Response--|        |                                   |          |
++---------+                             +--------+                                   +----------+
+```
+
+**Note** - Steps 2-4 (interaction between the client and OP) do not have to occur within the same transaction as steps 1 and 5 (interaction between the relying party and the client)
 
 # Credential Request
 


### PR DESCRIPTION
Renames the spec to OpenID Connect Credential Provider