### PR TITLE
feat: update spec, make signed request object optional

### DIFF
--- a/index.html
+++ b/index.html
@@ -1210,7 +1210,7 @@ tr:nth-child(2n+1) > td {
 <dl class="dlParallel" id="section-1.2-2">
           <dt id="section-1.2-2.1">Credential</dt>
 <dd id="section-1.2-2.2">
-            <p id="section-1.2-2.2.1">An assertion containing claims made about an End-User that has been bound in an authenticatable manner through the use of public/private key pairs to the requesting Client.<a href="#section-1.2-2.2.1" class="pilcrow">¶</a></p>
+            <p id="section-1.2-2.2.1">An assertion containing claims made about an End-User that has been bound in a provable manner through the use of public/private key pairs to the requesting Client.<a href="#section-1.2-2.2.1" class="pilcrow">¶</a></p>
 </dd>
 <dt id="section-1.2-2.3">Credential Request</dt>
 <dd id="section-1.2-2.4">
@@ -1218,7 +1218,7 @@ tr:nth-child(2n+1) > td {
 </dd>
 <dt id="section-1.2-2.5">Holder</dt>
 <dd id="section-1.2-2.6">
-            <p id="section-1.2-2.6.1">An entity that is tasked with holding credential(s) and presenting them to relying parties and the consent of and on behalf of the End-User (subject of the credential(s)).<a href="#section-1.2-2.6.1" class="pilcrow">¶</a></p>
+            <p id="section-1.2-2.6.1">An entity that is tasked with holding credential(s) and presenting them to relying parties on behalf of the consenting End-User (subject of the credential(s)).<a href="#section-1.2-2.6.1" class="pilcrow">¶</a></p>
 </dd>
 </dl>
 </section>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <meta content="John Thompson" name="author">
 <meta content="
        OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables relying parties to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User. 
-       In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as the  NASCAR problem  and  relying party tracking . 
+       In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as   relying party tracking . 
        This specification defines how an OpenID provider can be extended beyond being the provider of simple identity assertions into being the provider of credentials. 
     " name="description">
 <meta content="xml2rfc 2.40.1" name="generator">
@@ -1071,7 +1071,7 @@ tr:nth-child(2n+1) > td {
 <thead><tr>
 <td class="left"></td>
 <td class="center">OpenID Connect Credential Provider</td>
-<td class="right">July 2020</td>
+<td class="right">December 2020</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Looker &amp; Thompson</td>
@@ -1088,7 +1088,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">openid-credential-provider-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-07-31" class="published">31 July 2020</time>
+<time datetime="2020-12-14" class="published">14 December 2020</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1109,7 +1109,7 @@ tr:nth-child(2n+1) > td {
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables relying parties to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
-<p id="section-abstract-2">In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as the <a href="https://indieweb.org/NASCAR_problem">NASCAR problem</a> and <a href="https://github.com/WICG/WebID#the-rp-tracking-problem">relying party tracking</a>.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
+<p id="section-abstract-2">In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as  <a href="https://github.com/WICG/WebID#the-rp-tracking-problem">relying party tracking</a>.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
 <p id="section-abstract-3">This specification defines how an OpenID provider can be extended beyond being the provider of simple identity assertions into being the provider of credentials.<a href="#section-abstract-3" class="pilcrow">¶</a></p>
 </section>
 <div id="toc">
@@ -1136,19 +1136,16 @@ tr:nth-child(2n+1) > td {
             <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-credential-request" class="xref">Credential Request</a><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.1">
-                <p id="section-toc.1-1.2.2.1.1"><a href="#section-2.1" class="xref">2.1</a>.  <a href="#name-example" class="xref">Example</a><a href="#section-toc.1-1.2.2.1.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.1.1"><a href="#section-2.1" class="xref">2.1</a>.  <a href="#name-credential-request-2" class="xref">Credential Request</a><a href="#section-toc.1-1.2.2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.2">
-                <p id="section-toc.1-1.2.2.2.1"><a href="#section-2.2" class="xref">2.2</a>.  <a href="#name-request-parameters" class="xref">Request Parameters</a><a href="#section-toc.1-1.2.2.2.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.2.1"><a href="#section-2.2" class="xref">2.2</a>.  <a href="#name-signed-credential-request" class="xref">Signed Credential Request</a><a href="#section-toc.1-1.2.2.2.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.3">
-                <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="xref">2.3</a>.  <a href="#name-request-parameter" class="xref">Request Parameter</a><a href="#section-toc.1-1.2.2.3.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="xref">2.3</a>.  <a href="#name-request-parameters" class="xref">Request Parameters</a><a href="#section-toc.1-1.2.2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.4">
                 <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-response-types" class="xref">Response Types</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.2.2.5">
-                <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-requesting-a-credential-usi" class="xref">Requesting a credential using the credential request parameter</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
@@ -1159,7 +1156,10 @@ tr:nth-child(2n+1) > td {
                 <p id="section-toc.1-1.3.2.1.1"><a href="#section-3.1" class="xref">3.1</a>.  <a href="#name-credential" class="xref">Credential</a><a href="#section-toc.1-1.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.2">
-                <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="xref">3.2</a>.  <a href="#name-token-endpoint-response" class="xref">Token Endpoint Response</a><a href="#section-toc.1-1.3.2.2.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="xref">3.2</a>.  <a href="#name-credential-endpoint" class="xref">Credential Endpoint</a><a href="#section-toc.1-1.3.2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.3">
+                <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="xref">3.3</a>.  <a href="#name-token-endpoint-response-wit" class="xref">Token Endpoint Response (with credential)</a><a href="#section-toc.1-1.3.2.3.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
@@ -1167,7 +1167,7 @@ tr:nth-child(2n+1) > td {
             <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-usage-of-decentralized-iden" class="xref">Usage of Decentralized Identifiers</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.4.2.1">
-                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-credential-request-using-a-" class="xref">Credential Request using a Decentralized Identifier</a><a href="#section-toc.1-1.4.2.1.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-signed-credential-request-u" class="xref">Signed Credential Request using a Decentralized Identifier</a><a href="#section-toc.1-1.4.2.1.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
@@ -1189,7 +1189,7 @@ tr:nth-child(2n+1) > td {
 <a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
       </h2>
 <p id="section-1-1">OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables relying parties to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.<a href="#section-1-1" class="pilcrow">¶</a></p>
-<p id="section-1-2">In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as the <a href="https://indieweb.org/NASCAR_problem">NASCAR problem</a> and <a href="https://github.com/WICG/WebID#the-rp-tracking-problem">relying party tracking</a>.<a href="#section-1-2" class="pilcrow">¶</a></p>
+<p id="section-1-2">In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as  <a href="https://github.com/WICG/WebID#the-rp-tracking-problem">relying party tracking</a>.<a href="#section-1-2" class="pilcrow">¶</a></p>
 <p id="section-1-3">Typically the format of the assertion obtained about the End-User in the OpenID Connect protocol, known as the <code>id_token</code> or user assertion, is said to be bearer in nature, meaning it features no authenticatable binding to the Client that requested it. Therefore using this user assertion as a credential is impractical in many instances from a security perspective. Instead what is required for a user assertion to be suitable as a credential, is for it to feature some form of binding to the Client that requested it.<a href="#section-1-3" class="pilcrow">¶</a></p>
 <p id="section-1-4">This specification defines how the OpenID Connect protocol can be extended so that a supporting Client can obtain a credential on-behalf of an End-User. Where a credential is defined as an assertion about the End-User which is bound to the Client in an authenticatable manner based on public/private key cryptography. This feature then enables the Client to onward present the credential to other relying parties whilst authenticating the established binding to the assertion.<a href="#section-1-4" class="pilcrow">¶</a></p>
 <div id="requirements-notation-and-conventions">
@@ -1217,6 +1217,10 @@ tr:nth-child(2n+1) > td {
 <dd id="section-1.2-2.4">
             <p id="section-1.2-2.4.1">An OpenID Connect Authentication Request that results in the End-User being authenticated by the Authorization Server and the Client receiving a credential about the authenticated End-User.<a href="#section-1.2-2.4.1" class="pilcrow">¶</a></p>
 </dd>
+<dt id="section-1.2-2.5">Holder</dt>
+<dd id="section-1.2-2.6">
+            <p id="section-1.2-2.6.1">An entity that is tasked with holding credential(s) and presenting them to relying parties and the consent of and on behalf of the End-User (subject of the credential(s)).<a href="#section-1.2-2.6.1" class="pilcrow">¶</a></p>
+</dd>
 </dl>
 </section>
 </div>
@@ -1228,52 +1232,62 @@ tr:nth-child(2n+1) > td {
 <p id="section-1.3-1">This specification extends the OpenID Connect protocol for the purposes of credential issuance.<a href="#section-1.3-1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-1.3-2">
           <li id="section-1.3-2.1">
-            <p id="section-1.3-2.1.1">The Client sends a credential request to the OpenID Provider (OP).<a href="#section-1.3-2.1.1" class="pilcrow">¶</a></p>
+            <p id="section-1.3-2.1.1">The Holder acting as an OpenID Client sends a Credential Request to the Credential Provider that is acting as an OpenID Provider (OP).<a href="#section-1.3-2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-1.3-2.2">
-            <p id="section-1.3-2.2.1">The OpenID Provider authenticates the End-User and obtains authorization.<a href="#section-1.3-2.2.1" class="pilcrow">¶</a></p>
+            <p id="section-1.3-2.2.1">The Credential Provider authenticates the End-User and obtains authorization.<a href="#section-1.3-2.2.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-1.3-2.3">
-            <p id="section-1.3-2.3.1">The OpenID Provider responds with a Credential.<a href="#section-1.3-2.3.1" class="pilcrow">¶</a></p>
+            <p id="section-1.3-2.3.1">The Credential Provider responds with a Credential.<a href="#section-1.3-2.3.1" class="pilcrow">¶</a></p>
 </li>
 </ol>
 <p id="section-1.3-3">These steps are illustrated in the following diagram:<a href="#section-1.3-3" class="pilcrow">¶</a></p>
 <div class="artwork art-text alignLeft" id="section-1.3-4">
 <pre>+--------+                                   +----------+
 |        |                                   |          |
-|        |------(1) Credential Request------&gt;|          |
+|        |---(1)OpenID Credential Request---&gt;|          |
 |        |                                   |          |
 |        |  +--------+                       |          |
 |        |  |        |                       |          |
-| Client |  |  End-  |&lt;--(2) AuthN &amp; AuthZ--&gt;|    OP    |
-|        |  |  User  |                       |          |
-|        |  |        |                       |          |
+| Holder |  |  End-  |&lt;--(2) AuthN &amp; AuthZ--&gt;|Credential|
+|(Client)|  |  User  |                       | Provider |
+|        |  |        |                       |   (OP)   |
 |        |  +--------+                       |          |
 |        |                                   |          |
-|        |&lt;-----(3) Credential Response------|          |
+|        |&lt;--(3)OpenID Credential Response---|          |
 |        |                                   |          |
 +--------+                                   +----------+
 </pre><a href="#section-1.3-4" class="pilcrow">¶</a>
 </div>
-<p id="section-1.3-5"><strong>Note</strong> - Outside of the scope for this specification is how the client then exercises presentation of this credential with a relying party, however the overall diagram looks like the following.<a href="#section-1.3-5" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-1.3-6">
-<pre>+---------+                             +--------+                                   +----------+
-|         |--(1) Presentation Request--&gt;|        |                                   |          |
-|         |                             |        |------(2) Credential Request------&gt;|          |
-|         |                             |        |                                   |          |
-|         |                             |        |  +--------+                       |          |
-|         |                             |        |  |        |                       |          |
-| Relying |                             | Client |  |  End-  |&lt;--(3) AuthN &amp; AuthZ--&gt;|    OP    |
-|  Party  |                             |        |  |  User  |                       |          |
-|         |                             |        |  |        |                       |          |
-|         |                             |        |  +--------+                       |          |
-|         |                             |        |                                   |          |
-|         |                             |        |&lt;-----(4) Credential Response------|          |
-|         |&lt;-(5) Presentation Response--|        |                                   |          |
-+---------+                             +--------+                                   +----------+
-</pre><a href="#section-1.3-6" class="pilcrow">¶</a>
+<p id="section-1.3-5"><strong>Note</strong> - Outside of the scope for this specification is how the Holder then exercises presentation of this credential with a relying party, however the diagram looks like the following.<a href="#section-1.3-5" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-1.3-6">
+          <li id="section-1.3-6.1">
+            <p id="section-1.3-6.1.1">The Relying Party acting as an OpenID Client sends an OpenID Request to the Holder that is acting an OpenID Provider (OP).<a href="#section-1.3-6.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-1.3-6.2">
+            <p id="section-1.3-6.2.1">The Holder authenticates the End-User and obtains authorization.<a href="#section-1.3-6.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-1.3-6.3">
+            <p id="section-1.3-6.3.1">The Holder responds with a Credential Presentation.<a href="#section-1.3-6.3.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+<div class="artwork art-text alignLeft" id="section-1.3-7">
+<pre>+----------+                                                           +----------+
+|          |                                                           |          |
+|          |---(1)OpenID Connect Credential Presentation Request------&gt;|          |
+|          |                                                           |          |
+|          |                          +--------+                       |          |
+|          |                          |        |                       |          |
+| Relying  |                          |  End-  |&lt;--(2) AuthN &amp; AuthZ--&gt;|  Holder  |
+|  Party   |                          |  User  |                       |   (OP)   |
+| (Client) |                          |        |                       |          |
+|          |                          +--------+                       |          |
+|          |                                                           |          |
+|          |&lt;--(3)OpenID Connect Credential Presentation Response------|          |
+|          |                                                           |          |
++----------+                                                           +----------+
+</pre><a href="#section-1.3-7" class="pilcrow">¶</a>
 </div>
-<p id="section-1.3-7"><strong>Note</strong> - Steps 2-4 (interaction between the client and OP) do not have to occur within the same transaction as steps 1 and 5 (interaction between the relying party and the client)<a href="#section-1.3-7" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -1283,23 +1297,45 @@ tr:nth-child(2n+1) > td {
       <h2 id="name-credential-request">
 <a href="#section-2" class="section-number selfRef">2. </a><a href="#name-credential-request" class="section-name selfRef">Credential Request</a>
       </h2>
-<p id="section-2-1">A credential request is an OpenID Connect authentication request that requests that the End-User be authenticated by the Authorization Server and a credential containing the requested claims about the End-User be issued to the Client.<a href="#section-2-1" class="pilcrow">¶</a></p>
-<p id="section-2-2">The following section outlines how an <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest">OpenID Connect Authentication Request</a> must be extended in order for it to be a credential request.<a href="#section-2-2" class="pilcrow">¶</a></p>
-<div id="example">
+<p id="section-2-1">A Credential Request is an OpenID Connect authentication request made by a Holder that requests the End-User to be authenticated by the Credential Provider and consent be granted for a credential containing the requested claims about the End-User be issued to it.<a href="#section-2-1" class="pilcrow">¶</a></p>
+<p id="section-2-2">The following section outlines how an <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest">OpenID Connect Authentication Request</a> is extended in order to become a valid Credential Request.<a href="#section-2-2" class="pilcrow">¶</a></p>
+<div id="credential-request-1">
 <section id="section-2.1">
-        <h3 id="name-example">
-<a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-example" class="section-name selfRef">Example</a>
+        <h3 id="name-credential-request-2">
+<a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-credential-request-2" class="section-name selfRef">Credential Request</a>
         </h3>
-<p id="section-2.1-1">The credential request follows <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> including the required, but modified usage of the <code>request</code> parameter. The syntax around requesting claims to feature in the resulting credential is defined in <a href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">Section 5.5 of OpenID Connect Core 1.0</a> with the addition of the new top level member of <code>credential</code>.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
-<p id="section-2.1-2">A non-normative example of the Authorization request.<a href="#section-2.1-2" class="pilcrow">¶</a></p>
+<p id="section-2.1-1">The simplest OpenID Connect Credential Request is an ordinary OpenID Connect request that makes use of one additional scope, <code>openid_credential</code>.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+<p id="section-2.1-2">A non-normative example of the Credential Request.<a href="#section-2.1-2" class="pilcrow">¶</a></p>
 <div class="artwork art-text alignLeft" id="section-2.1-3">
+<pre>HTTP/1.1 302 Found
+Location: https://server.example.com/authorize?
+  response_type=code
+  &amp;scope=openid%20openid_credential
+  &amp;client_id=s6BhdRkqt3
+  &amp;state=af0ifjsldkj
+  &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+  &amp;credential_format=w3cvc-jsonld
+</pre><a href="#section-2.1-3" class="pilcrow">¶</a>
+</div>
+<p id="section-2.1-4">When a request of this nature is made, the <code>access_token</code> issued to the Client authorizes it to access the credential endpoint to obtain a credential.<a href="#section-2.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="signed-credential-request">
+<section id="section-2.2">
+        <h3 id="name-signed-credential-request">
+<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-signed-credential-request" class="section-name selfRef">Signed Credential Request</a>
+        </h3>
+<p id="section-2.2-1">When making a credential request, the Client can elect to sign the request, making use of the <a href="https://openid.net/specs/openid-connect-core-1_0.html#SignedRequestObject">signed request object</a> defined in OpenID Connect Core.<a href="#section-2.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.2-2">The following example documents this variation.<a href="#section-2.2-2" class="pilcrow">¶</a></p>
+<p id="section-2.2-3">A non-normative example of a Signed Credential request.<a href="#section-2.2-3" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-2.2-4">
 <pre>https://issuer.example.com/authorize
 ?scope=openid%20openid_credential
 &amp;request=&lt;signed-jwt-request-obj&gt;
-</pre><a href="#section-2.1-3" class="pilcrow">¶</a>
+</pre><a href="#section-2.2-4" class="pilcrow">¶</a>
 </div>
-<p id="section-2.1-4">Where the decoded payload of the request parameter is as follows<a href="#section-2.1-4" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-2.1-5">
+<p id="section-2.2-5">Where the decoded payload of the request parameter is as follows<a href="#section-2.2-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-2.2-6">
 <pre>{
   "response_type": "code",
   "client_id": "IAicV0pt9co5nn9D1tUKDCoPQq8BFlGH",
@@ -1311,59 +1347,44 @@ tr:nth-child(2n+1) > td {
     "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
   },
   "redirect_uri": "https://client.example.com/callback",
-  "credential_format": "w3cvc-jsonld",
-  "claims":
-  {
-    "credential": {
-      "given_name": {"essential": true},
-      "last_name": {"essential": true},
-      "https://www.w3.org/2018/credentials/examples/v1/degree": {"essential": true}
-    },
-  }
+  "credential_format": "w3cvc-jsonld"
 }
-</pre><a href="#section-2.1-5" class="pilcrow">¶</a>
+</pre><a href="#section-2.2-6" class="pilcrow">¶</a>
 </div>
-<p id="section-2.1-6">Where the jwt was signed by the key referenced in the <code>sub_jwk</code> section of the request.<a href="#section-2.1-6" class="pilcrow">¶</a></p>
+<p id="section-2.2-7">Where the jwt was signed by the key referenced in the <code>sub_jwk</code> section of the request.<a href="#section-2.2-7" class="pilcrow">¶</a></p>
+<p id="section-2.2-8">When a request of this nature is made, the resulting credential will be made available in the response body of the token endpoint.<a href="#section-2.2-8" class="pilcrow">¶</a></p>
+<p id="section-2.2-9">The value of the <code>request</code> parameter MUST either be a valid <a href="https://tools.ietf.org/html/rfc7519">JWT</a> or <a href="https://tools.ietf.org/html/rfc7516">JWE</a> whose claims are the credential request parameters, however the inner payload MUST be a valid <a href="https://tools.ietf.org/html/rfc7519">JWT</a> signed by the Client who created the request.<a href="#section-2.2-9" class="pilcrow">¶</a></p>
+<p id="section-2.2-10">The key used to sign the request object MUST validate to that featured in the <code>sub_jwk</code> parameter of the request.<a href="#section-2.2-10" class="pilcrow">¶</a></p>
+<p id="section-2.2-11">Unsigned plaintext Request Objects, containing <code>none</code> in the <code>alg</code> value of the JOSE header MUST not be supported.<a href="#section-2.2-11" class="pilcrow">¶</a></p>
+<p id="section-2.2-12">If the Request Object signing validation fails or is missing, the OpenID Connect Provider MUST respond to the request with the Error Response parameter, <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthError">section 3.1.2.6.</a> with Error code: <code>invalid_request_object</code>.<a href="#section-2.2-12" class="pilcrow">¶</a></p>
+<p id="section-2.2-13">If the <code>did</code> value is present in the request and the OpenID Provider does not support the usage of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a> the value should be ignored.<a href="#section-2.2-13" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="request-parameters">
-<section id="section-2.2">
+<section id="section-2.3">
         <h3 id="name-request-parameters">
-<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-request-parameters" class="section-name selfRef">Request Parameters</a>
+<a href="#section-2.3" class="section-number selfRef">2.3. </a><a href="#name-request-parameters" class="section-name selfRef">Request Parameters</a>
         </h3>
-<p id="section-2.2-1">A credential request uses the OpenID and OAuth2.0 request parameters as outlined in section <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest">3.1.2.1</a> of OpenID Connect core, except for the following additional constraints.<a href="#section-2.2-1" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-2.2-2">
-          <dt id="section-2.2-2.1">scope</dt>
-<dd id="section-2.2-2.2">
-            <p id="section-2.2-2.2.1">REQUIRED. A credential request MUST contain the <code>openid_credential</code> scope value in the second position directly after the <code>openid</code> scope.<a href="#section-2.2-2.2.1" class="pilcrow">¶</a></p>
+<p id="section-2.3-1">A Credential Request uses the OpenID and OAuth2.0 request parameters as outlined in section <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest">3.1.2.1</a> of OpenID Connect core, except for the following additional constraints.<a href="#section-2.3-1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-2.3-2">
+          <dt id="section-2.3-2.1">scope</dt>
+<dd id="section-2.3-2.2">
+            <p id="section-2.3-2.2.1">REQUIRED. A Credential Request MUST contain the <code>openid_credential</code> scope value in the second position directly after the <code>openid</code> scope.<a href="#section-2.3-2.2.1" class="pilcrow">¶</a></p>
 </dd>
-<dt id="section-2.2-2.3">credential_format</dt>
-<dd id="section-2.2-2.4">
-            <p id="section-2.2-2.4.1">REQUIRED. Determines the format of the credential returned at the end of the flow, values supported by the OpenID Provider are advertised in their openid-configuration metadata, under the <code>credential_formats_supported</code> attribute.<a href="#section-2.2-2.4.1" class="pilcrow">¶</a></p>
+<dt id="section-2.3-2.3">credential_format</dt>
+<dd id="section-2.3-2.4">
+            <p id="section-2.3-2.4.1">REQUIRED. Determines the format of the credential returned at the end of the flow, values supported by the OpenID Provider are advertised in their openid-configuration metadata, under the <code>credential_formats_supported</code> attribute.<a href="#section-2.3-2.4.1" class="pilcrow">¶</a></p>
 </dd>
-<dt id="section-2.2-2.5">sub_jwk</dt>
-<dd id="section-2.2-2.6">
-            <p id="section-2.2-2.6.1">REQUIRED. Defines the key material the client is requesting the credential to be bound to and the key responsible for signing the request object. Value is a JSON Object that is a valid <a href="https://tools.ietf.org/html/rfc7517">JWK</a>.<a href="#section-2.2-2.6.1" class="pilcrow">¶</a></p>
+<dt id="section-2.3-2.5">sub_jwk</dt>
+<dd id="section-2.3-2.6">
+            <p id="section-2.3-2.6.1">OPTIONAL. Used when making a Signed Credential Request, defines the key material the client is requesting the credential to be bound to and the key responsible for signing the request object. Value is a JSON Object that is a valid <a href="https://tools.ietf.org/html/rfc7517">JWK</a>.<a href="#section-2.3-2.6.1" class="pilcrow">¶</a></p>
 </dd>
-<dt id="section-2.2-2.7">did</dt>
-<dd id="section-2.2-2.8">
-            <p id="section-2.2-2.8.1">OPTIONAL. Defines the relationship between the key material the client is requesting the credential to be bound to and a <a href="https://w3c.github.io/did-core/">decentralized identifier</a>. Processing of this value requires the OpenID Provider to support the resolution of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a> which is advertised in their openid-configuration metadata, under the <code>dids_supported</code> attribute. The value of this field MUST be a valid <a href="https://w3c.github.io/did-core/">decentralized identifier</a>.<a href="#section-2.2-2.8.1" class="pilcrow">¶</a></p>
+<dt id="section-2.3-2.7">did</dt>
+<dd id="section-2.3-2.8">
+            <p id="section-2.3-2.8.1">OPTIONAL. Defines the relationship between the key material the client is requesting the credential to be bound to and a <a href="https://w3c.github.io/did-core/">decentralized identifier</a>. Processing of this value requires the OpenID Provider to support the resolution of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a> which is advertised in their openid-configuration metadata, under the <code>dids_supported</code> attribute. The value of this field MUST be a valid <a href="https://w3c.github.io/did-core/">decentralized identifier</a>.<a href="#section-2.3-2.8.1" class="pilcrow">¶</a></p>
 </dd>
 </dl>
-</section>
-</div>
-<div id="request-parameter">
-<section id="section-2.3">
-        <h3 id="name-request-parameter">
-<a href="#section-2.3" class="section-number selfRef">2.3. </a><a href="#name-request-parameter" class="section-name selfRef">Request Parameter</a>
-        </h3>
-<p id="section-2.3-1">Public private key pairs are used by a requesting Client to establish a means of binding to the resulting credential. A Client making a credential request to an OpenID Provider must prove control over this binding mechanism during the request, this is accomplished through the extended usage of a <a href="https://openid.net/specs/openid-connect-core-1_0.html#SignedRequestObject">signed request</a> defined in OpenID Connect Core.<a href="#section-2.3-1" class="pilcrow">¶</a></p>
-<p id="section-2.3-2">Usage of the <code>request</code> parameter as defined in section <a href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">5.5</a> of OpenID Connect core is REQUIRED in a credential request.<a href="#section-2.3-2" class="pilcrow">¶</a></p>
-<p id="section-2.3-3">The value of the <code>request</code> parameter MUST either be a valid <a href="https://tools.ietf.org/html/rfc7519">JWT</a> or <a href="https://tools.ietf.org/html/rfc7516">JWE</a> whose claims are the credential request parameters, however the inner payload MUST be a valid <a href="https://tools.ietf.org/html/rfc7519">JWT</a> signed by the Client who created the request.<a href="#section-2.3-3" class="pilcrow">¶</a></p>
-<p id="section-2.3-4">The key used to sign the request object MUST validate to that featured in the <code>sub_jwk</code> parameter of the request.<a href="#section-2.3-4" class="pilcrow">¶</a></p>
-<p id="section-2.3-5">Unsigned plaintext Request Objects, containing <code>none</code> in the <code>alg</code> value of the JOSE header MUST not be supported.<a href="#section-2.3-5" class="pilcrow">¶</a></p>
-<p id="section-2.3-6">If the Request Object signing validation fails or is missing, the OpenID Connect Provider MUST respond to the request with the Error Response parameter, <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthError">section 3.1.2.6.</a> with Error code: <code>invalid_request_object</code>.<a href="#section-2.3-6" class="pilcrow">¶</a></p>
-<p id="section-2.3-7">If the <code>did</code> value is present in the request and the OpenID Provider does not support the usage of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a> the value should be ignored.<a href="#section-2.3-7" class="pilcrow">¶</a></p>
+<p id="section-2.3-3">Public private key pairs are used by a requesting Client to establish a means of binding to the resulting credential. A Client making a Credential Request to an OpenID Provider must prove control over this binding mechanism during the request, this is accomplished through the extended usage of a <a href="https://openid.net/specs/openid-connect-core-1_0.html#SignedRequestObject">signed request</a> defined in OpenID Connect Core.<a href="#section-2.3-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="response-types">
@@ -1371,40 +1392,8 @@ tr:nth-child(2n+1) > td {
         <h3 id="name-response-types">
 <a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-response-types" class="section-name selfRef">Response Types</a>
         </h3>
-<p id="section-2.4-1">It is RECOMMENDED that a credential request flow use the <a href="https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps">authorization code flow</a> as defined in OpenID Connect core.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
+<p id="section-2.4-1">It is RECOMMENDED that a Credential Request flow use the <a href="https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps">authorization code flow</a> as defined in OpenID Connect core.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
 <p id="section-2.4-2">For instances where <a href="https://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth">implicit flow</a> is used, the <code>response_type</code> of <code>credential</code> SHOULD be used.<a href="#section-2.4-2" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="requesting-a-credential-using-the-credential-request-parameter">
-<section id="section-2.5">
-        <h3 id="name-requesting-a-credential-usi">
-<a href="#section-2.5" class="section-number selfRef">2.5. </a><a href="#name-requesting-a-credential-usi" class="section-name selfRef">Requesting a credential using the credential request parameter</a>
-        </h3>
-<p id="section-2.5-1">A non-normative example of a payload of a signed Request Object.<a href="#section-2.5-1" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-2.5-2">
-<pre>{
-  "response_type": "code",
-  "client_id": "IAicV0pt9co5nn9D1tUKDCoPQq8BFlGH",
-  "sub_jwk" : {
-    "crv":"secp256k1",
-    "kid":"YkDpvGNsch2lFBf6p8u3",
-    "kty":"EC",
-    "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
-    "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
-  },
-  "redirect_uri": "https://client.example.com/callback",
-  "credential_format": "w3cvc-jsonld",
-  "claims":
-  {
-    "credential": {
-      "given_name": {"essential": true},
-      "last_name": {"essential": true},
-      "https://www.w3.org/2018/credentials/examples/v1/degree": {"essential": true}
-    },
-  }
-}
-</pre><a href="#section-2.5-2" class="pilcrow">¶</a>
-</div>
 </section>
 </div>
 </section>
@@ -1419,7 +1408,7 @@ tr:nth-child(2n+1) > td {
         <h3 id="name-credential">
 <a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-credential" class="section-name selfRef">Credential</a>
         </h3>
-<p id="section-3.1-1">A Credential is a Client bound assertion describing the End-User authenticated in an OpenID flow. Formats of the Credential can vary, examples include JSON-LD or JWT based Credentials, the OpenID provider SHOULD make the supported credential formats available at their openid-configuration meta-data endpoint.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
+<p id="section-3.1-1">Formats of the Credential can vary, examples include JSON-LD or JWT based Credentials, the OpenID provider SHOULD make the supported credential formats available at their openid-configuration meta-data endpoint.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
 <p id="section-3.1-2">The following is a non-normative example of a Credential issued as a <a href="https://www.w3.org/TR/vc-data-model/">W3C Verifiable Credential 1.0</a> compliant format in JSON-LD.<a href="#section-3.1-2" class="pilcrow">¶</a></p>
 <div class="artwork art-text alignLeft" id="section-3.1-3">
 <pre>{
@@ -1485,16 +1474,24 @@ tr:nth-child(2n+1) > td {
 </div>
 </section>
 </div>
-<div id="token-endpoint-response">
+<div id="credential-endpoint">
 <section id="section-3.2">
-        <h3 id="name-token-endpoint-response">
-<a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-token-endpoint-response" class="section-name selfRef">Token Endpoint Response</a>
+        <h3 id="name-credential-endpoint">
+<a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-credential-endpoint" class="section-name selfRef">Credential Endpoint</a>
         </h3>
-<p id="section-3.2-1">Successful and Error Authentication Response are in the same manor as <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> with the <code>code</code> parameter always being returned with the Authorization Code Flow.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
-<p id="section-3.2-2">On Request to the Token Endpoint the <code>grant_type</code> value MUST be <code>authorization_code</code> inline with the Authorization Code Flow and the <code>code</code> value included as a parameter.<a href="#section-3.2-2" class="pilcrow">¶</a></p>
-<p id="section-3.2-3">The Response from the Token Endpoint MUST include the Credential in the form of an object with value for <code>format</code> indicating the credentials format and <code>data</code> containing the Credential.<a href="#section-3.2-3" class="pilcrow">¶</a></p>
-<p id="section-3.2-4">The following is a non-normative example of a response from the token endpoint featuring a JSON-LD based Credential.<a href="#section-3.2-4" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.2-5">
+<p id="section-3.2-1">TODO<a href="#section-3.2-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="token-endpoint-response-with-credential">
+<section id="section-3.3">
+        <h3 id="name-token-endpoint-response-wit">
+<a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-token-endpoint-response-wit" class="section-name selfRef">Token Endpoint Response (with credential)</a>
+        </h3>
+<p id="section-3.3-1">If the OpenID Connect request is a Signed Credential Request. The Response from the Token Endpoint MUST include the Credential in the form of an object with value for <code>format</code> indicating the credentials format and <code>data</code> containing the Credential.<a href="#section-3.3-1" class="pilcrow">¶</a></p>
+<p id="section-3.3-2">Successful and Error Authentication Response are in the same manor as <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> with the <code>code</code> parameter always being returned with the Authorization Code Flow.<a href="#section-3.3-2" class="pilcrow">¶</a></p>
+<p id="section-3.3-3">On Request to the Token Endpoint the <code>grant_type</code> value MUST be <code>authorization_code</code> inline with the Authorization Code Flow and the <code>code</code> value included as a parameter.<a href="#section-3.3-3" class="pilcrow">¶</a></p>
+<p id="section-3.3-4">The following is a non-normative example of a response from the token endpoint featuring a JSON-LD based Credential.<a href="#section-3.3-4" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.3-5">
 <pre>{
   "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ",
   "token_type": "bearer",
@@ -1535,10 +1532,10 @@ tr:nth-child(2n+1) > td {
     }
   }
 }
-</pre><a href="#section-3.2-5" class="pilcrow">¶</a>
+</pre><a href="#section-3.3-5" class="pilcrow">¶</a>
 </div>
-<p id="section-3.2-6">The following is a non-normative example of a response from the token endpoint featuring a JWT based credential<a href="#section-3.2-6" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.2-7">
+<p id="section-3.3-6">The following is a non-normative example of a response from the token endpoint featuring a JWT based credential<a href="#section-3.3-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.3-7">
 <pre>{
   "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ",
   "token_type": "bearer",
@@ -1549,10 +1546,10 @@ tr:nth-child(2n+1) > td {
     "data": "ewogICJhbGciOiAiRVMyNTYiLAogICJ0eXAiOiAiSldUIgp9.ewogICJpc3MiOiAiaXNzdWVyIjogImh0dHBzOi8vaXNzdWVyLmVkdSIsCiAgInN1YiI6ICJkaWQ6ZXhhbXBsZToxMjM0NTYiLAogICJpYXQiOiAxNTkxMDY5MDU2LAogICJleHAiOiAxNTkxMDY5NTU2LAogICJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy9leGFtcGxlcy92MS9kZWdyZWUiOiB7CiAgICAgImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxL3R5cGUiOiAiQmFjaGVsb3JEZWdyZWUiLAogICAgICJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy9leGFtcGxlcy92MS9uYW1lIjogIkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiCiAgfQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
   }
 }
-</pre><a href="#section-3.2-7" class="pilcrow">¶</a>
+</pre><a href="#section-3.3-7" class="pilcrow">¶</a>
 </div>
-<p id="section-3.2-8">And the decoded Claim Set of the JWT<a href="#section-3.2-8" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.2-9">
+<p id="section-3.3-8">And the decoded Claim Set of the JWT<a href="#section-3.3-8" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.3-9">
 <pre>{
   "iss": "issuer": "https://issuer.edu",
   "sub": "123456789",
@@ -1570,7 +1567,7 @@ tr:nth-child(2n+1) > td {
      "https://www.w3.org/2018/credentials/examples/v1/name": "Bachelor of Science and Arts"
   }
 }
-</pre><a href="#section-3.2-9" class="pilcrow">¶</a>
+</pre><a href="#section-3.3-9" class="pilcrow">¶</a>
 </div>
 </section>
 </div>
@@ -1581,16 +1578,16 @@ tr:nth-child(2n+1) > td {
       <h2 id="name-usage-of-decentralized-iden">
 <a href="#section-4" class="section-number selfRef">4. </a><a href="#name-usage-of-decentralized-iden" class="section-name selfRef">Usage of Decentralized Identifiers</a>
       </h2>
-<p id="section-4-1"><a href="https://w3c.github.io/did-core/">Decentralized identifiers</a> are a resolvable identifier to a set of statements about the <a href="https://w3c.github.io/did-core/#dfn-did-subjects">did subject</a> including a set of cryptographic material (e.g public keys). Using this cryptographic material, a <a href="https://w3c.github.io/did-core/">decentralized identifier</a> can be used as an authenticatable identifier in a credential.<a href="#section-4-1" class="pilcrow">¶</a></p>
-<div id="credential-request-using-a-decentralized-identifier">
+<p id="section-4-1"><a href="https://w3c.github.io/did-core/">Decentralized identifiers</a> are a resolvable identifier to a set of statements about the <a href="https://w3c.github.io/did-core/#dfn-did-subjects">did subject</a> including a set of cryptographic material (e.g public keys). Using this cryptographic material, a <a href="https://w3c.github.io/did-core/">decentralized identifier</a> can be used as an authenticatable identifier in a credential, rather than using a public key directly.<a href="#section-4-1" class="pilcrow">¶</a></p>
+<div id="signed-credential-request-using-a-decentralized-identifier">
 <section id="section-4.1">
-        <h3 id="name-credential-request-using-a-">
-<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-credential-request-using-a-" class="section-name selfRef">Credential Request using a Decentralized Identifier</a>
+        <h3 id="name-signed-credential-request-u">
+<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-signed-credential-request-u" class="section-name selfRef">Signed Credential Request using a Decentralized Identifier</a>
         </h3>
-<p id="section-4.1-1">A Client can request in the credential issuance flow, that the resulting credential be bound to the client through the usage of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a> by using the <code>did</code> field.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
-<p id="section-4.1-2">A Client prior to submitting a credential request SHOULD validate that the OpenID Provider supports the resolution of decentralized identifiers by retrieving their openid-configuration metadata to check if an attribute of <code>dids_supported</code> has a value of <code>true</code>.<a href="#section-4.1-2" class="pilcrow">¶</a></p>
-<p id="section-4.1-3">The Client SHOULD also validate that the OpenID Provider supports the <a href="https://w3c-ccg.github.io/did-method-registry/">did method</a> to be used in the request by retrieving their openid-configuration metadata to check if an attribute of <code>did_methods_supported</code> contains the required did method.<a href="#section-4.1-3" class="pilcrow">¶</a></p>
-<p id="section-4.1-4">An OpenID Provider processing a credential request featuring a <a href="https://w3c.github.io/did-core/">decentralized identifier</a> MUST follow the following additional steps to validate the request.<a href="#section-4.1-4" class="pilcrow">¶</a></p>
+<p id="section-4.1-1">A Holder submitting a signed Credential Request can request, that the resulting credential be bound to the Holder through the usage of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a> by using the <code>did</code> field.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
+<p id="section-4.1-2">A Holder prior to submitting a credential request SHOULD validate that the Credential Provider supports the resolution of decentralized identifiers by retrieving their openid-configuration metadata to check if an attribute of <code>dids_supported</code> has a value of <code>true</code>.<a href="#section-4.1-2" class="pilcrow">¶</a></p>
+<p id="section-4.1-3">The Holder SHOULD also validate that the Credential Provider supports the <a href="https://w3c-ccg.github.io/did-method-registry/">did method</a> to be used in the request by retrieving their openid-configuration metadata to check if an attribute of <code>did_methods_supported</code> contains the required did method.<a href="#section-4.1-3" class="pilcrow">¶</a></p>
+<p id="section-4.1-4">A Credential Provider processing a credential request featuring a <a href="https://w3c.github.io/did-core/">decentralized identifier</a> MUST follow the following additional steps to validate the request.<a href="#section-4.1-4" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-4.1-5">
           <li id="section-4.1-5.1">
             <p id="section-4.1-5.1.1">Validate the value in the <code>did</code> field is a valid <a href="https://w3c.github.io/did-core/">decentralized identifier</a>.<a href="#section-4.1-5.1.1" class="pilcrow">¶</a></p>
@@ -1617,15 +1614,8 @@ tr:nth-child(2n+1) > td {
   },
   "did": "did:example:1234",
   "redirect_uri": "https://Client.example.com/callback",
-  "credential_format": "w3cvc-jsonld",
-  "claims":
-  {
-    "credential": {
-      "given_name": {"essential": true},
-      "last_name": {"essential": true},
-      "https://www.w3.org/2018/credentials/examples/v1/degree": {"essential": true}
-    },
-  }
+  "credential_format": "w3cvc-jsonld"
+
 }
 </pre><a href="#section-4.1-8" class="pilcrow">¶</a>
 </div>

--- a/index.html
+++ b/index.html
@@ -1088,7 +1088,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">openid-credential-provider-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-12-14" class="published">14 December 2020</time>
+<time datetime="2020-12-20" class="published">20 December 2020</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1190,8 +1190,7 @@ tr:nth-child(2n+1) > td {
       </h2>
 <p id="section-1-1">OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables relying parties to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.<a href="#section-1-1" class="pilcrow">¶</a></p>
 <p id="section-1-2">In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as  <a href="https://github.com/WICG/WebID#the-rp-tracking-problem">relying party tracking</a>.<a href="#section-1-2" class="pilcrow">¶</a></p>
-<p id="section-1-3">Typically the format of the assertion obtained about the End-User in the OpenID Connect protocol, known as the <code>id_token</code> or user assertion, is said to be bearer in nature, meaning it features no authenticatable binding to the Client that requested it. Therefore using this user assertion as a credential is impractical in many instances from a security perspective. Instead what is required for a user assertion to be suitable as a credential, is for it to feature some form of binding to the Client that requested it.<a href="#section-1-3" class="pilcrow">¶</a></p>
-<p id="section-1-4">This specification defines how the OpenID Connect protocol can be extended so that a supporting Client can obtain a credential on-behalf of an End-User. Where a credential is defined as an assertion about the End-User which is bound to the Client in an authenticatable manner based on public/private key cryptography. This feature then enables the Client to onward present the credential to other relying parties whilst authenticating the established binding to the assertion.<a href="#section-1-4" class="pilcrow">¶</a></p>
+<p id="section-1-3">This specification defines how the OpenID Connect protocol can be extended so that a supporting Client can obtain a credential on-behalf of an End-User. Where a credential is defined as an assertion about the End-User which is bound to the Client in an authenticatable manner based on public/private key cryptography. This feature then enables the Client to onward present the credential to other relying parties whilst authenticating the established binding to the assertion.<a href="#section-1-3" class="pilcrow">¶</a></p>
 <div id="requirements-notation-and-conventions">
 <section id="section-1.1">
         <h3 id="name-requirements-notation-and-c">

--- a/index.html
+++ b/index.html
@@ -1088,7 +1088,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">openid-credential-provider-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-12-20" class="published">20 December 2020</time>
+<time datetime="2020-12-21" class="published">21 December 2020</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1541,8 +1541,23 @@ Location: https://server.example.com/authorize?
   "expires_in": 86400,
   "id_token": "eyJodHRwOi8vbWF0dHIvdGVuYW50L..3Mz",
   "credential": {
-    "format": "jwt",
-    "data": "ewogICJhbGciOiAiRVMyNTYiLAogICJ0eXAiOiAiSldUIgp9.ewogICJpc3MiOiAiaXNzdWVyIjogImh0dHBzOi8vaXNzdWVyLmVkdSIsCiAgInN1YiI6ICJkaWQ6ZXhhbXBsZToxMjM0NTYiLAogICJpYXQiOiAxNTkxMDY5MDU2LAogICJleHAiOiAxNTkxMDY5NTU2LAogICJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy9leGFtcGxlcy92MS9kZWdyZWUiOiB7CiAgICAgImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxL3R5cGUiOiAiQmFjaGVsb3JEZWdyZWUiLAogICAgICJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy9leGFtcGxlcy92MS9uYW1lIjogIkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiCiAgfQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+      "format": "w3cvc-jwt",
+      "data":
+          "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRpZDpleGFtcGxlOmFiZmUxM2Y3MTIxMjA0
+          MzFjMjc2ZTEyZWNhYiNrZXlzLTEifQ.eyJzdWIiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxY
+          zI3NmUxMmVjMjEiLCJqdGkiOiJodHRwOi8vZXhhbXBsZS5lZHUvY3JlZGVudGlhbHMvMzczMiIsImlzc
+          yI6Imh0dHBzOi8vZXhhbXBsZS5jb20va2V5cy9mb28uandrIiwibmJmIjoxNTQxNDkzNzI0LCJpYXQiO
+          jE1NDE0OTM3MjQsImV4cCI6MTU3MzAyOTcyMywibm9uY2UiOiI2NjAhNjM0NUZTZXIiLCJ2YyI6eyJAY
+          29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd
+          3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZ
+          UNyZWRlbnRpYWwiLCJVbml2ZXJzaXR5RGVncmVlQ3JlZGVudGlhbCJdLCJjcmVkZW50aWFsU3ViamVjd
+          CI6eyJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IjxzcGFuIGxhbmc9J2ZyL
+          UNBJz5CYWNjYWxhdXLDqWF0IGVuIG11c2lxdWVzIG51bcOpcmlxdWVzPC9zcGFuPiJ9fX19.KLJo5GAy
+          BND3LDTn9H7FQokEsUEi8jKwXhGvoN3JtRa51xrNDgXDb0cq1UTYB-rK4Ft9YVmR1NI_ZOF8oGc_7wAp
+          8PHbF2HaWodQIoOBxxT-4WNqAxft7ET6lkH-4S6Ux3rSGAmczMohEEf8eCeN-jC8WekdPl6zKZQj0YPB
+          1rx6X0-xlFBs7cl6Wt8rfBP_tZ9YgVWrQmUWypSioc0MUyiphmyEbLZagTyPlUyflGlEdqrZAv6eSe6R
+          txJy6M1-lD7a5HTzanYTWBPAUHDZGyGKXdJw-W_x0IWChBzI8t3kpG253fg6V3tPgHeKXE94fz_QpYfg
+          --7kLsyBAfQGbg"
   }
 }
 </pre><a href="#section-3.3-7" class="pilcrow">¶</a>
@@ -1559,11 +1574,22 @@ Location: https://server.example.com/authorize?
     "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
     "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
   },
-  "iat": 1591069056,
-  "exp": 1591069556,
-  "https://www.w3.org/2018/credentials/examples/v1/degree": {
-     "https://www.w3.org/2018/credentials/examples/v1/type": "BachelorDegree",
-     "https://www.w3.org/2018/credentials/examples/v1/name": "Bachelor of Science and Arts"
+  "nbf": 1541493724,
+  "iat": 1541493724,
+  "exp": 1573029723,
+  "nonce": "660!6345FSer",
+  "vc": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1"
+    ],
+    "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+    "credentialSubject": {
+      "degree": {
+        "type": "BachelorDegree",
+        "name": "Bachelor of Science and Arts"
+      }
+    }
   }
 }
 </pre><a href="#section-3.3-9" class="pilcrow">¶</a>

--- a/spec.md
+++ b/spec.md
@@ -46,8 +46,6 @@ OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. 
 
 In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as  [relying party tracking](https://github.com/WICG/WebID#the-rp-tracking-problem).
 
-Typically the format of the assertion obtained about the End-User in the OpenID Connect protocol, known as the `id_token` or user assertion, is said to be bearer in nature, meaning it features no authenticatable binding to the Client that requested it. Therefore using this user assertion as a credential is impractical in many instances from a security perspective. Instead what is required for a user assertion to be suitable as a credential, is for it to feature some form of binding to the Client that requested it.
-
 This specification defines how the OpenID Connect protocol can be extended so that a supporting Client can obtain a credential on-behalf of an End-User. Where a credential is defined as an assertion about the End-User which is bound to the Client in an authenticatable manner based on public/private key cryptography. This feature then enables the Client to onward present the credential to other relying parties whilst authenticating the established binding to the assertion.
 
 ## Requirements Notation and Conventions

--- a/spec.md
+++ b/spec.md
@@ -34,7 +34,7 @@ email = "john.thompson@mattr.global"
 
 OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables relying parties to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.
 
-In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as the [NASCAR problem](https://indieweb.org/NASCAR_problem) and [relying party tracking](https://github.com/WICG/WebID#the-rp-tracking-problem).
+In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as  [relying party tracking](https://github.com/WICG/WebID#the-rp-tracking-problem).
 
 This specification defines how an OpenID provider can be extended beyond being the provider of simple identity assertions into being the provider of credentials.
 
@@ -44,7 +44,7 @@ This specification defines how an OpenID provider can be extended beyond being t
 
 OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0 protocol. It enables relying parties to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User.
 
-In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as the [NASCAR problem](https://indieweb.org/NASCAR_problem) and [relying party tracking](https://github.com/WICG/WebID#the-rp-tracking-problem).
+In typical deployments of OpenID Connect today to be able to exercise the identity an End-User has with an OpenID Provider with a relying party, the relying party must be in direct contact with the provider. This constraint causes issues such as  [relying party tracking](https://github.com/WICG/WebID#the-rp-tracking-problem).
 
 Typically the format of the assertion obtained about the End-User in the OpenID Connect protocol, known as the `id_token` or user assertion, is said to be bearer in nature, meaning it features no authenticatable binding to the Client that requested it. Therefore using this user assertion as a credential is impractical in many instances from a security perspective. Instead what is required for a user assertion to be suitable as a credential, is for it to feature some form of binding to the Client that requested it.
 
@@ -68,65 +68,91 @@ Credential
 Credential Request
 : An OpenID Connect Authentication Request that results in the End-User being authenticated by the Authorization Server and the Client receiving a credential about the authenticated End-User.
 
+Holder
+: An entity that is tasked with holding credential(s) and presenting them to relying parties and the consent of and on behalf of the End-User (subject of the credential(s)). 
+
 ## Overview
 
 This specification extends the OpenID Connect protocol for the purposes of credential issuance.
 
-1. The Client sends a credential request to the OpenID Provider (OP).
-2. The OpenID Provider authenticates the End-User and obtains authorization.
-3. The OpenID Provider responds with a Credential.
+1. The Holder acting as an OpenID Client sends a Credential Request to the Credential Provider that is acting as an OpenID Provider (OP).
+2. The Credential Provider authenticates the End-User and obtains authorization.
+3. The Credential Provider responds with a Credential.
 
 These steps are illustrated in the following diagram:
 
 ```
 +--------+                                   +----------+
 |        |                                   |          |
-|        |------(1) Credential Request------>|          |
+|        |---(1)OpenID Credential Request--->|          |
 |        |                                   |          |
 |        |  +--------+                       |          |
 |        |  |        |                       |          |
-| Client |  |  End-  |<--(2) AuthN & AuthZ-->|    OP    |
-|        |  |  User  |                       |          |
-|        |  |        |                       |          |
+| Holder |  |  End-  |<--(2) AuthN & AuthZ-->|Credential|
+|(Client)|  |  User  |                       | Provider |
+|        |  |        |                       |   (OP)   |
 |        |  +--------+                       |          |
 |        |                                   |          |
-|        |<-----(3) Credential Response------|          |
+|        |<--(3)OpenID Credential Response---|          |
 |        |                                   |          |
 +--------+                                   +----------+
 ```
 
-**Note** - Outside of the scope for this specification is how the client then exercises presentation of this credential with a relying party, however the overall diagram looks like the following.
+**Note** - Outside of the scope for this specification is how the Holder then exercises presentation of this credential with a relying party, however the diagram looks like the following.
+
+1. The Relying Party acting as an OpenID Client sends an OpenID Request to the Holder that is acting an OpenID Provider (OP).
+2. The Holder authenticates the End-User and obtains authorization.
+3. The Holder responds with a Credential Presentation.
 
 ```
-+---------+                             +--------+                                   +----------+
-|         |--(1) Presentation Request-->|        |                                   |          |
-|         |                             |        |------(2) Credential Request------>|          |
-|         |                             |        |                                   |          |
-|         |                             |        |  +--------+                       |          |
-|         |                             |        |  |        |                       |          |
-| Relying |                             | Client |  |  End-  |<--(3) AuthN & AuthZ-->|    OP    |
-|  Party  |                             |        |  |  User  |                       |          |
-|         |                             |        |  |        |                       |          |
-|         |                             |        |  +--------+                       |          |
-|         |                             |        |                                   |          |
-|         |                             |        |<-----(4) Credential Response------|          |
-|         |<-(5) Presentation Response--|        |                                   |          |
-+---------+                             +--------+                                   +----------+
++----------+                                                           +----------+
+|          |                                                           |          |
+|          |---(1)OpenID Connect Credential Presentation Request------>|          |
+|          |                                                           |          |
+|          |                          +--------+                       |          |
+|          |                          |        |                       |          |
+| Relying  |                          |  End-  |<--(2) AuthN & AuthZ-->|  Holder  |
+|  Party   |                          |  User  |                       |   (OP)   |
+| (Client) |                          |        |                       |          |
+|          |                          +--------+                       |          |
+|          |                                                           |          |
+|          |<--(3)OpenID Connect Credential Presentation Response------|          |
+|          |                                                           |          |
++----------+                                                           +----------+
 ```
-
-**Note** - Steps 2-4 (interaction between the client and OP) do not have to occur within the same transaction as steps 1 and 5 (interaction between the relying party and the client)
 
 # Credential Request
 
-A credential request is an OpenID Connect authentication request that requests that the End-User be authenticated by the Authorization Server and a credential containing the requested claims about the End-User be issued to the Client.
+A Credential Request is an OpenID Connect authentication request made by a Holder that requests the End-User to be authenticated by the Credential Provider and consent be granted for a credential containing the requested claims about the End-User be issued to it.
 
-The following section outlines how an [OpenID Connect Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) must be extended in order for it to be a credential request.
+The following section outlines how an [OpenID Connect Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) is extended in order to become a valid Credential Request.
 
-## Example
+## Credential Request
 
-The credential request follows [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) including the required, but modified usage of the `request` parameter. The syntax around requesting claims to feature in the resulting credential is defined in [Section 5.5 of OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter) with the addition of the new top level member of `credential`.
+The simplest OpenID Connect Credential Request is an ordinary OpenID Connect request that makes use of one additional scope, `openid_credential`.
 
-A non-normative example of the Authorization request.
+A non-normative example of the Credential Request.
+
+```
+HTTP/1.1 302 Found
+Location: https://server.example.com/authorize?
+  response_type=code
+  &scope=openid%20openid_credential
+  &client_id=s6BhdRkqt3
+  &state=af0ifjsldkj
+  &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+  &credential_format=w3cvc-jsonld
+```
+
+When a request of this nature is made, the `access_token` issued to the Client authorizes it to access the credential endpoint to obtain a credential.
+
+## Signed Credential Request
+
+When making a credential request, the Client can elect to sign the request, making use of the [signed request object](https://openid.net/specs/openid-connect-core-1_0.html#SignedRequestObject) defined in OpenID Connect Core.
+
+The following example documents this variation.
+
+A non-normative example of a Signed Credential request.
 
 ```
 https://issuer.example.com/authorize
@@ -148,41 +174,13 @@ Where the decoded payload of the request parameter is as follows
     "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
   },
   "redirect_uri": "https://client.example.com/callback",
-  "credential_format": "w3cvc-jsonld",
-  "claims":
-  {
-    "credential": {
-      "given_name": {"essential": true},
-      "last_name": {"essential": true},
-      "https://www.w3.org/2018/credentials/examples/v1/degree": {"essential": true}
-    },
-  }
+  "credential_format": "w3cvc-jsonld"
 }
 ```
 
 Where the jwt was signed by the key referenced in the `sub_jwk` section of the request.
 
-## Request Parameters
-
-A credential request uses the OpenID and OAuth2.0 request parameters as outlined in section [3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) of OpenID Connect core, except for the following additional constraints.
-
-scope
-: REQUIRED. A credential request MUST contain the `openid_credential` scope value in the second position directly after the `openid` scope.
-
-credential_format
-: REQUIRED. Determines the format of the credential returned at the end of the flow, values supported by the OpenID Provider are advertised in their openid-configuration metadata, under the `credential_formats_supported` attribute.
-
-sub_jwk
-: REQUIRED. Defines the key material the client is requesting the credential to be bound to and the key responsible for signing the request object. Value is a JSON Object that is a valid [JWK](https://tools.ietf.org/html/rfc7517).
-
-did
-: OPTIONAL. Defines the relationship between the key material the client is requesting the credential to be bound to and a [decentralized identifier](https://w3c.github.io/did-core/). Processing of this value requires the OpenID Provider to support the resolution of [decentralized identifiers](https://w3c.github.io/did-core/) which is advertised in their openid-configuration metadata, under the `dids_supported` attribute. The value of this field MUST be a valid [decentralized identifier](https://w3c.github.io/did-core/).
-
-## Request Parameter
-
-Public private key pairs are used by a requesting Client to establish a means of binding to the resulting credential. A Client making a credential request to an OpenID Provider must prove control over this binding mechanism during the request, this is accomplished through the extended usage of a [signed request](https://openid.net/specs/openid-connect-core-1_0.html#SignedRequestObject) defined in OpenID Connect Core.
-
-Usage of the `request` parameter as defined in section [5.5](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter) of OpenID Connect core is REQUIRED in a credential request.
+When a request of this nature is made, the resulting credential will be made available in the response body of the token endpoint.
 
 The value of the `request` parameter MUST either be a valid [JWT](https://tools.ietf.org/html/rfc7519) or [JWE](https://tools.ietf.org/html/rfc7516) whose claims are the credential request parameters, however the inner payload MUST be a valid [JWT](https://tools.ietf.org/html/rfc7519) signed by the Client who created the request.
 
@@ -194,45 +192,36 @@ If the Request Object signing validation fails or is missing, the OpenID Connect
 
 If the `did` value is present in the request and the OpenID Provider does not support the usage of [decentralized identifiers](https://w3c.github.io/did-core/) the value should be ignored.
 
+## Request Parameters
+
+A Credential Request uses the OpenID and OAuth2.0 request parameters as outlined in section [3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) of OpenID Connect core, except for the following additional constraints.
+
+scope
+: REQUIRED. A Credential Request MUST contain the `openid_credential` scope value in the second position directly after the `openid` scope.
+
+credential_format
+: REQUIRED. Determines the format of the credential returned at the end of the flow, values supported by the OpenID Provider are advertised in their openid-configuration metadata, under the `credential_formats_supported` attribute.
+
+sub_jwk
+: OPTIONAL. Used when making a Signed Credential Request, defines the key material the client is requesting the credential to be bound to and the key responsible for signing the request object. Value is a JSON Object that is a valid [JWK](https://tools.ietf.org/html/rfc7517).
+
+did
+: OPTIONAL. Defines the relationship between the key material the client is requesting the credential to be bound to and a [decentralized identifier](https://w3c.github.io/did-core/). Processing of this value requires the OpenID Provider to support the resolution of [decentralized identifiers](https://w3c.github.io/did-core/) which is advertised in their openid-configuration metadata, under the `dids_supported` attribute. The value of this field MUST be a valid [decentralized identifier](https://w3c.github.io/did-core/).
+
+Public private key pairs are used by a requesting Client to establish a means of binding to the resulting credential. A Client making a Credential Request to an OpenID Provider must prove control over this binding mechanism during the request, this is accomplished through the extended usage of a [signed request](https://openid.net/specs/openid-connect-core-1_0.html#SignedRequestObject) defined in OpenID Connect Core.
+
+
 ## Response Types
 
-It is RECOMMENDED that a credential request flow use the [authorization code flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps) as defined in OpenID Connect core.
+It is RECOMMENDED that a Credential Request flow use the [authorization code flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps) as defined in OpenID Connect core.
 
 For instances where [implicit flow](https://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth) is used, the `response_type` of `credential` SHOULD be used.
-
-## Requesting a credential using the credential request parameter
-
-A non-normative example of a payload of a signed Request Object.
-
-```
-{
-  "response_type": "code",
-  "client_id": "IAicV0pt9co5nn9D1tUKDCoPQq8BFlGH",
-  "sub_jwk" : {
-    "crv":"secp256k1",
-    "kid":"YkDpvGNsch2lFBf6p8u3",
-    "kty":"EC",
-    "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
-    "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
-  },
-  "redirect_uri": "https://client.example.com/callback",
-  "credential_format": "w3cvc-jsonld",
-  "claims":
-  {
-    "credential": {
-      "given_name": {"essential": true},
-      "last_name": {"essential": true},
-      "https://www.w3.org/2018/credentials/examples/v1/degree": {"essential": true}
-    },
-  }
-}
-```
 
 # Credential Response
 
 ## Credential
 
-A Credential is a Client bound assertion describing the End-User authenticated in an OpenID flow. Formats of the Credential can vary, examples include JSON-LD or JWT based Credentials, the OpenID provider SHOULD make the supported credential formats available at their openid-configuration meta-data endpoint.
+Formats of the Credential can vary, examples include JSON-LD or JWT based Credentials, the OpenID provider SHOULD make the supported credential formats available at their openid-configuration meta-data endpoint.
 
 The following is a non-normative example of a Credential issued as a [W3C Verifiable Credential 1.0](https://www.w3.org/TR/vc-data-model/) compliant format in JSON-LD.
 
@@ -300,13 +289,18 @@ And the decoded Claim Set of the JWT
 }
 ```
 
-## Token Endpoint Response
+## Credential Endpoint
+
+TODO
+
+
+## Token Endpoint Response (with credential)
+
+If the OpenID Connect request is a Signed Credential Request. The Response from the Token Endpoint MUST include the Credential in the form of an object with value for `format` indicating the credentials format and `data` containing the Credential.
 
 Successful and Error Authentication Response are in the same manor as [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) with the `code` parameter always being returned with the Authorization Code Flow.
 
 On Request to the Token Endpoint the `grant_type` value MUST be `authorization_code` inline with the Authorization Code Flow and the `code` value included as a parameter.
-
-The Response from the Token Endpoint MUST include the Credential in the form of an object with value for `format` indicating the credentials format and `data` containing the Credential.
 
 The following is a non-normative example of a response from the token endpoint featuring a JSON-LD based Credential.
 
@@ -393,17 +387,17 @@ And the decoded Claim Set of the JWT
 
 # Usage of Decentralized Identifiers
 
-[Decentralized identifiers](https://w3c.github.io/did-core/) are a resolvable identifier to a set of statements about the [did subject](https://w3c.github.io/did-core/#dfn-did-subjects) including a set of cryptographic material (e.g public keys). Using this cryptographic material, a [decentralized identifier](https://w3c.github.io/did-core/) can be used as an authenticatable identifier in a credential. 
+[Decentralized identifiers](https://w3c.github.io/did-core/) are a resolvable identifier to a set of statements about the [did subject](https://w3c.github.io/did-core/#dfn-did-subjects) including a set of cryptographic material (e.g public keys). Using this cryptographic material, a [decentralized identifier](https://w3c.github.io/did-core/) can be used as an authenticatable identifier in a credential, rather than using a public key directly. 
 
-## Credential Request using a Decentralized Identifier
+## Signed Credential Request using a Decentralized Identifier
 
-A Client can request in the credential issuance flow, that the resulting credential be bound to the client through the usage of [decentralized identifiers](https://w3c.github.io/did-core/) by using the `did` field.
+A Holder submitting a signed Credential Request can request, that the resulting credential be bound to the Holder through the usage of [decentralized identifiers](https://w3c.github.io/did-core/) by using the `did` field.
 
-A Client prior to submitting a credential request SHOULD validate that the OpenID Provider supports the resolution of decentralized identifiers by retrieving their openid-configuration metadata to check if an attribute of `dids_supported` has a value of `true`.
+A Holder prior to submitting a credential request SHOULD validate that the Credential Provider supports the resolution of decentralized identifiers by retrieving their openid-configuration metadata to check if an attribute of `dids_supported` has a value of `true`.
 
-The Client SHOULD also validate that the OpenID Provider supports the [did method](https://w3c-ccg.github.io/did-method-registry/) to be used in the request by retrieving their openid-configuration metadata to check if an attribute of `did_methods_supported` contains the required did method.
+The Holder SHOULD also validate that the Credential Provider supports the [did method](https://w3c-ccg.github.io/did-method-registry/) to be used in the request by retrieving their openid-configuration metadata to check if an attribute of `did_methods_supported` contains the required did method.
 
-An OpenID Provider processing a credential request featuring a [decentralized identifier](https://w3c.github.io/did-core/) MUST follow the following additional steps to validate the request.
+A Credential Provider processing a credential request featuring a [decentralized identifier](https://w3c.github.io/did-core/) MUST follow the following additional steps to validate the request.
 
 1. Validate the value in the `did` field is a valid [decentralized identifier](https://w3c.github.io/did-core/).
 2. Resolve this the `did` value to a [did document](https://w3c.github.io/did-core/#dfn-did-documents).
@@ -426,15 +420,8 @@ The following is a non-normative example of requesting the issuance of a credent
   },
   "did": "did:example:1234",
   "redirect_uri": "https://Client.example.com/callback",
-  "credential_format": "w3cvc-jsonld",
-  "claims":
-  {
-    "credential": {
-      "given_name": {"essential": true},
-      "last_name": {"essential": true},
-      "https://www.w3.org/2018/credentials/examples/v1/degree": {"essential": true}
-    },
-  }
+  "credential_format": "w3cvc-jsonld"                                
+
 }
 ```
 

--- a/spec.md
+++ b/spec.md
@@ -61,13 +61,13 @@ All uses of JSON Web Signature (JWS) [JWS](https://tools.ietf.org/html/rfc7515) 
 This specification uses the terms defined in OpenID Connect Core 1.0; in addition, the following terms are also defined:
 
 Credential
-: An assertion containing claims made about an End-User that has been bound in an authenticatable manner through the use of public/private key pairs to the requesting Client.
+: An assertion containing claims made about an End-User that has been bound in a provable manner through the use of public/private key pairs to the requesting Client.
 
 Credential Request
 : An OpenID Connect Authentication Request that results in the End-User being authenticated by the Authorization Server and the Client receiving a credential about the authenticated End-User.
 
 Holder
-: An entity that is tasked with holding credential(s) and presenting them to relying parties and the consent of and on behalf of the End-User (subject of the credential(s)). 
+: An entity that is tasked with holding credential(s) and presenting them to relying parties on behalf of the consenting End-User (subject of the credential(s)). 
 
 ## Overview
 

--- a/spec.md
+++ b/spec.md
@@ -354,8 +354,23 @@ The following is a non-normative example of a response from the token endpoint f
   "expires_in": 86400,
   "id_token": "eyJodHRwOi8vbWF0dHIvdGVuYW50L..3Mz",
   "credential": {
-    "format": "jwt",
-    "data": "ewogICJhbGciOiAiRVMyNTYiLAogICJ0eXAiOiAiSldUIgp9.ewogICJpc3MiOiAiaXNzdWVyIjogImh0dHBzOi8vaXNzdWVyLmVkdSIsCiAgInN1YiI6ICJkaWQ6ZXhhbXBsZToxMjM0NTYiLAogICJpYXQiOiAxNTkxMDY5MDU2LAogICJleHAiOiAxNTkxMDY5NTU2LAogICJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy9leGFtcGxlcy92MS9kZWdyZWUiOiB7CiAgICAgImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxL3R5cGUiOiAiQmFjaGVsb3JEZWdyZWUiLAogICAgICJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy9leGFtcGxlcy92MS9uYW1lIjogIkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiCiAgfQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+      "format": "w3cvc-jwt",
+      "data": 
+          "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRpZDpleGFtcGxlOmFiZmUxM2Y3MTIxMjA0
+          MzFjMjc2ZTEyZWNhYiNrZXlzLTEifQ.eyJzdWIiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxY
+          zI3NmUxMmVjMjEiLCJqdGkiOiJodHRwOi8vZXhhbXBsZS5lZHUvY3JlZGVudGlhbHMvMzczMiIsImlzc
+          yI6Imh0dHBzOi8vZXhhbXBsZS5jb20va2V5cy9mb28uandrIiwibmJmIjoxNTQxNDkzNzI0LCJpYXQiO
+          jE1NDE0OTM3MjQsImV4cCI6MTU3MzAyOTcyMywibm9uY2UiOiI2NjAhNjM0NUZTZXIiLCJ2YyI6eyJAY
+          29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd
+          3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZ
+          UNyZWRlbnRpYWwiLCJVbml2ZXJzaXR5RGVncmVlQ3JlZGVudGlhbCJdLCJjcmVkZW50aWFsU3ViamVjd
+          CI6eyJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IjxzcGFuIGxhbmc9J2ZyL
+          UNBJz5CYWNjYWxhdXLDqWF0IGVuIG11c2lxdWVzIG51bcOpcmlxdWVzPC9zcGFuPiJ9fX19.KLJo5GAy
+          BND3LDTn9H7FQokEsUEi8jKwXhGvoN3JtRa51xrNDgXDb0cq1UTYB-rK4Ft9YVmR1NI_ZOF8oGc_7wAp
+          8PHbF2HaWodQIoOBxxT-4WNqAxft7ET6lkH-4S6Ux3rSGAmczMohEEf8eCeN-jC8WekdPl6zKZQj0YPB
+          1rx6X0-xlFBs7cl6Wt8rfBP_tZ9YgVWrQmUWypSioc0MUyiphmyEbLZagTyPlUyflGlEdqrZAv6eSe6R
+          txJy6M1-lD7a5HTzanYTWBPAUHDZGyGKXdJw-W_x0IWChBzI8t3kpG253fg6V3tPgHeKXE94fz_QpYfg
+          --7kLsyBAfQGbg"
   }
 }
 ```
@@ -373,15 +388,25 @@ And the decoded Claim Set of the JWT
     "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
     "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
   },
-  "iat": 1591069056,
-  "exp": 1591069556,
-  "https://www.w3.org/2018/credentials/examples/v1/degree": {
-     "https://www.w3.org/2018/credentials/examples/v1/type": "BachelorDegree",
-     "https://www.w3.org/2018/credentials/examples/v1/name": "Bachelor of Science and Arts"
+  "nbf": 1541493724,
+  "iat": 1541493724,
+  "exp": 1573029723,
+  "nonce": "660!6345FSer",
+  "vc": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1"
+    ],
+    "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+    "credentialSubject": {
+      "degree": {
+        "type": "BachelorDegree",
+        "name": "Bachelor of Science and Arts"
+      }
+    }
   }
 }
 ```
-
 
 # Usage of Decentralized Identifiers
 
@@ -472,10 +497,10 @@ An OpenID provider can use the following meta-data elements to advertise its sup
 : A JSON array of strings identifying the resulting format of the credential issued at the end of the flow.
 
 `credential_claims_supported`
-: A JSON array of strings identifying the claim names supported within an issued credential. 
+: A JSON array of strings identifying the claim names supported within an issued credential.
 
 `credential_name`
-: A human readable string to identify the name of the credential offered by the provider. 
+: A human readable string to identify the name of the credential offered by the provider.
 
 `dids_supported`
 : Boolean value indicating that the OpenID provider supports the resolution of [decentralized identifiers](https://w3c.github.io/did-core/).
@@ -503,7 +528,7 @@ The following is a non-normative example of the relevant entries in the openid-c
     "last_name",
     "https://www.w3.org/2018/credentials/examples/v1/degree"
   ],
-  "credential_name": "University Credential" 
+  "credential_name": "University Credential"
 }
 ```
 


### PR DESCRIPTION
A variety of language updates include the introduction of the holder role.

Makes the signed request object optional, specs out where the `/credential` endpoint will be defined in the spec