### PR TITLE
Add draft of the credential endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -1088,7 +1088,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">openid-credential-provider-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-01-06" class="published">6 January 2021</time>
+<time datetime="2021-01-10" class="published">10 January 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1550,13 +1550,9 @@ Authorization: Bearer &lt;access-token&gt;
   },
   "iat": 1591069056,
   "exp": 1591069556,
-  "vc": {
-    "credentialSubject": {
-      "https://www.w3.org/2018/credentials/examples/v1/degree": {
-        "https://www.w3.org/2018/credentials/examples/v1/type": "BachelorDegree",
-        "https://www.w3.org/2018/credentials/examples/v1/name": "Bachelor of Science and Arts"
-      }
-    }
+  "https://www.w3.org/2018/credentials/examples/v1/degree": {
+    "https://www.w3.org/2018/credentials/examples/v1/type": "BachelorDegree",
+    "https://www.w3.org/2018/credentials/examples/v1/name": "Bachelor of Science and Arts"
   }
 }
 </pre><a href="#section-4.1-7" class="pilcrow">¶</a>

--- a/index.html
+++ b/index.html
@@ -1090,7 +1090,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">openid-credential-provider-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-01-15" class="published">15 January 2021</time>
+<time datetime="2021-01-20" class="published">20 January 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1439,7 +1439,7 @@ Location: https://server.example.com/authorize?
       <h2 id="name-credential-endpoint">
 <a href="#section-3" class="section-number selfRef">3. </a><a href="#name-credential-endpoint" class="section-name selfRef">Credential Endpoint</a>
       </h2>
-<p id="section-3-1">The Credential Endpoint is an OAuth 2.0 Protected Resource that when called, returns Claims about the authenticated End-User in the form of a credential. To obtain the requested Claims about the End-User, the Client makes a request to the UserInfo Endpoint using an Access Token obtained through OpenID Connect Authentication whereby the the <code>openid_credential</code> scope was granted.<a href="#section-3-1" class="pilcrow">¶</a></p>
+<p id="section-3-1">The Credential Endpoint is an OAuth 2.0 Protected Resource that when called, returns Claims about the authenticated End-User in the form of a credential. To obtain a credential on behalf of the End-User, the Client makes a request to the Credential Endpoint using an Access Token obtained through OpenID Connect Authentication whereby the the <code>openid_credential</code> scope was granted.<a href="#section-3-1" class="pilcrow">¶</a></p>
 <p id="section-3-2">Communication with the Credential Endpoint MUST utilize TLS. See Section 16.17 for more information on using TLS.<a href="#section-3-2" class="pilcrow">¶</a></p>
 <p id="section-3-3">The Credential Endpoint MUST support the use of HTTP POST methods defined in RFC 2616 [RFC2616].<a href="#section-3-3" class="pilcrow">¶</a></p>
 <p id="section-3-4">It is recommended that the Credential Endpoint SHOULD enforce presentation of the OAuth2.0 Access Token to be sender constrained <a href="https://tools.ietf.org/html/draft-fett-oauth-dpop-04">DPOP</a>. However the Credential Endpoint MUST also accept Access Tokens as OAuth 2.0 Bearer Token Usage [RFC6750]. (Note: do we remove?)<a href="#section-3-4" class="pilcrow">¶</a></p>
@@ -1450,8 +1450,8 @@ Location: https://server.example.com/authorize?
 <a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-credential-endpoint-request" class="section-name selfRef">Credential Endpoint Request Parameters</a>
         </h3>
 <p id="section-3.1-1">The Holder may provide a signed request object containing the <code>sub</code> to be used as the subject for the resulting credential.  When a <code>sub</code> claim is present within the request object an associated <code>sub_jwk</code> claim MUST also be present of which the request object MUST be signed with, therefore proving control over the <code>sub</code>.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
-<p id="section-3.1-2">The Holder may also specify the <code>credential_format</code> they wish the credential to be returned in, given it is supported by the Credential Provider. If not specified or not supported the Credential Provider will use their preferred default format. (Note if we are going to have a default we need to specify it)<a href="#section-3.1-2" class="pilcrow">¶</a></p>
-<p id="section-3.1-3">When a signed request is not provided the Credential Provider will use the <code>sub</code> associated with the initial <code>auth</code> request, where possible.  If a <code>sub</code> value is not available an error should be returned by the Credential Provider.<a href="#section-3.1-3" class="pilcrow">¶</a></p>
+<p id="section-3.1-2">The Holder may also specify the <code>credential_format</code> they wish the returned credential to be formatted as. If the provider receiving the request does not support the requested credential format they it MUST return an error response, as per [TODO]. If the credential_format is not specified in the request SHOULD respond with their preferred or default format. (Note if we are going to have a default we need to specify it or is it at the discretion of the provider to determine this?)<a href="#section-3.1-2" class="pilcrow">¶</a></p>
+<p id="section-3.1-3">When a signed request is not provided the Credential Provider will use the <code>sub</code> associated with the initial <code>auth</code> request, where possible.  If a <code>sub</code> value is not available the provider MUST return an error response, as per [TODO].<a href="#section-3.1-3" class="pilcrow">¶</a></p>
 <dl class="dlParallel" id="section-3.1-4">
           <dt id="section-3.1-4.1">request</dt>
 <dd id="section-3.1-4.2">

--- a/index.html
+++ b/index.html
@@ -1071,7 +1071,7 @@ tr:nth-child(2n+1) > td {
 <thead><tr>
 <td class="left"></td>
 <td class="center">OpenID Connect Credential Provider</td>
-<td class="right">December 2020</td>
+<td class="right">January 2021</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Looker &amp; Thompson</td>
@@ -1088,7 +1088,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">openid-credential-provider-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2020-12-21" class="published">21 December 2020</time>
+<time datetime="2021-01-05" class="published">5 January 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1156,10 +1156,13 @@ tr:nth-child(2n+1) > td {
                 <p id="section-toc.1-1.3.2.1.1"><a href="#section-3.1" class="xref">3.1</a>.  <a href="#name-credential" class="xref">Credential</a><a href="#section-toc.1-1.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.2">
-                <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="xref">3.2</a>.  <a href="#name-credential-endpoint" class="xref">Credential Endpoint</a><a href="#section-toc.1-1.3.2.2.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="xref">3.2</a>.  <a href="#name-token-endpoint-response" class="xref">Token Endpoint Response</a><a href="#section-toc.1-1.3.2.2.1" class="pilcrow">¶</a></p>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.3">
-                <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="xref">3.3</a>.  <a href="#name-token-endpoint-response-wit" class="xref">Token Endpoint Response (with credential)</a><a href="#section-toc.1-1.3.2.3.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="xref">3.3</a>.  <a href="#name-credential-endpoint" class="xref">Credential Endpoint</a><a href="#section-toc.1-1.3.2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.4">
+                <p id="section-toc.1-1.3.2.4.1"><a href="#section-3.4" class="xref">3.4</a>.  <a href="#name-token-endpoint-response-wit" class="xref">Token Endpoint Response (with credential)</a><a href="#section-toc.1-1.3.2.4.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
@@ -1473,24 +1476,43 @@ Location: https://server.example.com/authorize?
 </div>
 </section>
 </div>
-<div id="credential-endpoint">
+<div id="token-endpoint-response">
 <section id="section-3.2">
-        <h3 id="name-credential-endpoint">
-<a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-credential-endpoint" class="section-name selfRef">Credential Endpoint</a>
+        <h3 id="name-token-endpoint-response">
+<a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-token-endpoint-response" class="section-name selfRef">Token Endpoint Response</a>
         </h3>
-<p id="section-3.2-1">TODO<a href="#section-3.2-1" class="pilcrow">¶</a></p>
+<p id="section-3.2-1">Successful and Error Authentication Response are in the same manor as <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> with the <code>code</code> parameter always being returned with the Authorization Code Flow.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
+<p id="section-3.2-2">On Request to the Token Endpoint the <code>grant_type</code> value MUST be <code>authorization_code</code> inline with the Authorization Code Flow and the <code>code</code> value included as a parameter.<a href="#section-3.2-2" class="pilcrow">¶</a></p>
+<p id="section-3.2-3">The following is a non-normative example of a response from the token endpoint, whereby the <code>access_token</code> authorizes the Holder to request a <code>credential</code> from the credential endpoint.<a href="#section-3.2-3" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.2-4">
+<pre>{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ",
+  "token_type": "bearer",
+  "expires_in": 86400,
+  "id_token": "eyJodHRwOi8vbWF0dHIvdGVuYW50L..3Mz"
+}
+</pre><a href="#section-3.2-4" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+<div id="credential-endpoint">
+<section id="section-3.3">
+        <h3 id="name-credential-endpoint">
+<a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-credential-endpoint" class="section-name selfRef">Credential Endpoint</a>
+        </h3>
+<p id="section-3.3-1">TODO<a href="#section-3.3-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="token-endpoint-response-with-credential">
-<section id="section-3.3">
+<section id="section-3.4">
         <h3 id="name-token-endpoint-response-wit">
-<a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-token-endpoint-response-wit" class="section-name selfRef">Token Endpoint Response (with credential)</a>
+<a href="#section-3.4" class="section-number selfRef">3.4. </a><a href="#name-token-endpoint-response-wit" class="section-name selfRef">Token Endpoint Response (with credential)</a>
         </h3>
-<p id="section-3.3-1">If the OpenID Connect request is a Signed Credential Request. The Response from the Token Endpoint MUST include the Credential in the form of an object with value for <code>format</code> indicating the credentials format and <code>data</code> containing the Credential.<a href="#section-3.3-1" class="pilcrow">¶</a></p>
-<p id="section-3.3-2">Successful and Error Authentication Response are in the same manor as <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> with the <code>code</code> parameter always being returned with the Authorization Code Flow.<a href="#section-3.3-2" class="pilcrow">¶</a></p>
-<p id="section-3.3-3">On Request to the Token Endpoint the <code>grant_type</code> value MUST be <code>authorization_code</code> inline with the Authorization Code Flow and the <code>code</code> value included as a parameter.<a href="#section-3.3-3" class="pilcrow">¶</a></p>
-<p id="section-3.3-4">The following is a non-normative example of a response from the token endpoint featuring a JSON-LD based Credential.<a href="#section-3.3-4" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.3-5">
+<p id="section-3.4-1">If the OpenID Connect request is a Signed Credential Request. The Response from the Token Endpoint MUST include the Credential in the form of an object with value for <code>format</code> indicating the credentials format and <code>data</code> containing the Credential.<a href="#section-3.4-1" class="pilcrow">¶</a></p>
+<p id="section-3.4-2">Successful and Error Authentication Response are in the same manor as <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> with the <code>code</code> parameter always being returned with the Authorization Code Flow.<a href="#section-3.4-2" class="pilcrow">¶</a></p>
+<p id="section-3.4-3">On Request to the Token Endpoint the <code>grant_type</code> value MUST be <code>authorization_code</code> inline with the Authorization Code Flow and the <code>code</code> value included as a parameter.<a href="#section-3.4-3" class="pilcrow">¶</a></p>
+<p id="section-3.4-4">The following is a non-normative example of a response from the token endpoint featuring a JSON-LD based Credential.<a href="#section-3.4-4" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.4-5">
 <pre>{
   "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ",
   "token_type": "bearer",
@@ -1531,10 +1553,10 @@ Location: https://server.example.com/authorize?
     }
   }
 }
-</pre><a href="#section-3.3-5" class="pilcrow">¶</a>
+</pre><a href="#section-3.4-5" class="pilcrow">¶</a>
 </div>
-<p id="section-3.3-6">The following is a non-normative example of a response from the token endpoint featuring a JWT based credential<a href="#section-3.3-6" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.3-7">
+<p id="section-3.4-6">The following is a non-normative example of a response from the token endpoint featuring a JWT based credential<a href="#section-3.4-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.4-7">
 <pre>{
   "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ",
   "token_type": "bearer",
@@ -1560,10 +1582,10 @@ Location: https://server.example.com/authorize?
           --7kLsyBAfQGbg"
   }
 }
-</pre><a href="#section-3.3-7" class="pilcrow">¶</a>
+</pre><a href="#section-3.4-7" class="pilcrow">¶</a>
 </div>
-<p id="section-3.3-8">And the decoded Claim Set of the JWT<a href="#section-3.3-8" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.3-9">
+<p id="section-3.4-8">And the decoded Claim Set of the JWT<a href="#section-3.4-8" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.4-9">
 <pre>{
   "iss": "issuer": "https://issuer.edu",
   "sub": "123456789",
@@ -1592,7 +1614,7 @@ Location: https://server.example.com/authorize?
     }
   }
 }
-</pre><a href="#section-3.3-9" class="pilcrow">¶</a>
+</pre><a href="#section-3.4-9" class="pilcrow">¶</a>
 </div>
 </section>
 </div>

--- a/index.html
+++ b/index.html
@@ -1088,7 +1088,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">openid-credential-provider-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-01-10" class="published">10 January 2021</time>
+<time datetime="2021-01-12" class="published">12 January 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1429,15 +1429,18 @@ Location: https://server.example.com/authorize?
       <h2 id="name-credential-endpoint">
 <a href="#section-3" class="section-number selfRef">3. </a><a href="#name-credential-endpoint" class="section-name selfRef">Credential Endpoint</a>
       </h2>
-<p id="section-3-1">The credential endpoint is used by a Holder to request the issuance of a verifiable credential from a Credential Provder (OP).<a href="#section-3-1" class="pilcrow">¶</a></p>
-<p id="section-3-2">The Holder MUST use the <code>access_token</code> previously acquired in the token endpoint response from the Credential Provider as an authorization header.  It is recommended that the <code>access_token</code> be sender constrained (Note: do we require this or leave as optional based on the Credential Provider's preference, to provide a DPoP example).<a href="#section-3-2" class="pilcrow">¶</a></p>
+<p id="section-3-1">The Credential Endpoint is an OAuth 2.0 Protected Resource that when called, returns Claims about the authenticated End-User in the form of a credential. To obtain the requested Claims about the End-User, the Client makes a request to the UserInfo Endpoint using an Access Token obtained through OpenID Connect Authentication whereby the the <code>openid_credential</code> scope was granted.<a href="#section-3-1" class="pilcrow">¶</a></p>
+<p id="section-3-2">Communication with the Credential Endpoint MUST utilize TLS. See Section 16.17 for more information on using TLS.<a href="#section-3-2" class="pilcrow">¶</a></p>
+<p id="section-3-3">The Credential Endpoint MUST support the use of HTTP POST methods defined in RFC 2616 [RFC2616].<a href="#section-3-3" class="pilcrow">¶</a></p>
+<p id="section-3-4">It is recommended that the Credential Endpoint SHOULD enforce presentation of the OAuth2.0 Access Token to be sender constrained <a href="https://tools.ietf.org/html/draft-fett-oauth-dpop-04">DPOP</a>. However the Credential Endpoint MUST also accept Access Tokens as OAuth 2.0 Bearer Token Usage [RFC6750]. (Note: do we remove?)<a href="#section-3-4" class="pilcrow">¶</a></p>
+<p id="section-3-5">The Credential Endpoint SHOULD support the use of Cross Origin Resource Sharing (CORS) [CORS] and or other methods as appropriate to enable Java Script Clients to access the endpoint.<a href="#section-3-5" class="pilcrow">¶</a></p>
 <div id="credential-endpoint-request-parameters">
 <section id="section-3.1">
         <h3 id="name-credential-endpoint-request">
 <a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-credential-endpoint-request" class="section-name selfRef">Credential Endpoint Request Parameters</a>
         </h3>
 <p id="section-3.1-1">The Holder may provide a signed request object containing the <code>sub</code> to be used as the subject for the resulting credential.  When a <code>sub</code> claim is present within the request object an associated <code>sub_jwk</code> claim MUST also be present of which the request object MUST be signed with, therefore proving control over the <code>sub</code>.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
-<p id="section-3.1-2">The Holder may also specify the <code>credential_format</code> they wish the credential to be returned in, given it is supported by the Credential Provider. If not specified or not supported the Credential Provider will use their preferred default format.<a href="#section-3.1-2" class="pilcrow">¶</a></p>
+<p id="section-3.1-2">The Holder may also specify the <code>credential_format</code> they wish the credential to be returned in, given it is supported by the Credential Provider. If not specified or not supported the Credential Provider will use their preferred default format. (Note if we are going to have a default we need to specify it)<a href="#section-3.1-2" class="pilcrow">¶</a></p>
 <p id="section-3.1-3">When a signed request is not provided the Credential Provider will use the <code>sub</code> associated with the initial <code>auth</code> request, where possible.  If a <code>sub</code> value is not available an error should be returned by the Credential Provider.<a href="#section-3.1-3" class="pilcrow">¶</a></p>
 <dl class="dlParallel" id="section-3.1-4">
           <dt id="section-3.1-4.1">request</dt>
@@ -1450,7 +1453,10 @@ Location: https://server.example.com/authorize?
 <pre>POST /credential HTTP/1.1
 Host: https://issuer.example.com
 Authorization: Bearer &lt;access-token&gt;
-  request=&lt;signed-jwt-request-obj&gt;
+Content-Type: application/json
+{
+  "request": &lt;signed-jwt-request-obj&gt;
+}
 </pre><a href="#section-3.1-6" class="pilcrow">¶</a>
 </div>
 <p id="section-3.1-7">Where the decoded payload of the request parameter is as follows:<a href="#section-3.1-7" class="pilcrow">¶</a></p>

--- a/index.html
+++ b/index.html
@@ -1088,7 +1088,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">openid-credential-provider-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-01-05" class="published">5 January 2021</time>
+<time datetime="2021-01-06" class="published">6 January 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1147,38 +1147,43 @@ tr:nth-child(2n+1) > td {
 <li class="toc ulEmpty" id="section-toc.1-1.2.2.4">
                 <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="xref">2.4</a>.  <a href="#name-response-types" class="xref">Response Types</a><a href="#section-toc.1-1.2.2.4.1" class="pilcrow">¶</a></p>
 </li>
+<li class="toc ulEmpty" id="section-toc.1-1.2.2.5">
+                <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="xref">2.5</a>.  <a href="#name-token-endpoint-response" class="xref">Token Endpoint Response</a><a href="#section-toc.1-1.2.2.5.1" class="pilcrow">¶</a></p>
+</li>
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-credential-response" class="xref">Credential Response</a><a href="#section-toc.1-1.3.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-credential-endpoint" class="xref">Credential Endpoint</a><a href="#section-toc.1-1.3.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.1">
-                <p id="section-toc.1-1.3.2.1.1"><a href="#section-3.1" class="xref">3.1</a>.  <a href="#name-credential" class="xref">Credential</a><a href="#section-toc.1-1.3.2.1.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.2">
-                <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="xref">3.2</a>.  <a href="#name-token-endpoint-response" class="xref">Token Endpoint Response</a><a href="#section-toc.1-1.3.2.2.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.3">
-                <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="xref">3.3</a>.  <a href="#name-credential-endpoint" class="xref">Credential Endpoint</a><a href="#section-toc.1-1.3.2.3.1" class="pilcrow">¶</a></p>
-</li>
-<li class="toc ulEmpty" id="section-toc.1-1.3.2.4">
-                <p id="section-toc.1-1.3.2.4.1"><a href="#section-3.4" class="xref">3.4</a>.  <a href="#name-token-endpoint-response-wit" class="xref">Token Endpoint Response (with credential)</a><a href="#section-toc.1-1.3.2.4.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.3.2.1.1"><a href="#section-3.1" class="xref">3.1</a>.  <a href="#name-credential-endpoint-request" class="xref">Credential Endpoint Request Parameters</a><a href="#section-toc.1-1.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-usage-of-decentralized-iden" class="xref">Usage of Decentralized Identifiers</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-credential-response" class="xref">Credential Response</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.4.2.1">
-                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-signed-credential-request-u" class="xref">Signed Credential Request using a Decentralized Identifier</a><a href="#section-toc.1-1.4.2.1.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-credential" class="xref">Credential</a><a href="#section-toc.1-1.4.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.4.2.2">
+                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-token-endpoint-response-wit" class="xref">Token Endpoint Response (with credential)</a><a href="#section-toc.1-1.4.2.2.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
 <li class="toc ulEmpty" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-openid-provider-metadata" class="xref">OpenID Provider Metadata</a><a href="#section-toc.1-1.5.1" class="pilcrow">¶</a></p>
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-usage-of-decentralized-iden" class="xref">Usage of Decentralized Identifiers</a><a href="#section-toc.1-1.5.1" class="pilcrow">¶</a></p>
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.5.2.1">
-                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="xref">5.1</a>.  <a href="#name-url-construction" class="xref">URL Construction</a><a href="#section-toc.1-1.5.2.1.1" class="pilcrow">¶</a></p>
+                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="xref">5.1</a>.  <a href="#name-signed-credential-request-u" class="xref">Signed Credential Request using a Decentralized Identifier</a><a href="#section-toc.1-1.5.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-openid-provider-metadata" class="xref">OpenID Provider Metadata</a><a href="#section-toc.1-1.6.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.6.2.1">
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-url-construction" class="xref">URL Construction</a><a href="#section-toc.1-1.6.2.1.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
@@ -1398,21 +1403,99 @@ Location: https://server.example.com/authorize?
 <p id="section-2.4-2">For instances where <a href="https://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth">implicit flow</a> is used, the <code>response_type</code> of <code>credential</code> SHOULD be used.<a href="#section-2.4-2" class="pilcrow">¶</a></p>
 </section>
 </div>
+<div id="token-endpoint-response">
+<section id="section-2.5">
+        <h3 id="name-token-endpoint-response">
+<a href="#section-2.5" class="section-number selfRef">2.5. </a><a href="#name-token-endpoint-response" class="section-name selfRef">Token Endpoint Response</a>
+        </h3>
+<p id="section-2.5-1">Successful and Error Authentication Response are in the same manor as <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> with the <code>code</code> parameter always being returned with the Authorization Code Flow.<a href="#section-2.5-1" class="pilcrow">¶</a></p>
+<p id="section-2.5-2">On Request to the Token Endpoint the <code>grant_type</code> value MUST be <code>authorization_code</code> inline with the Authorization Code Flow and the <code>code</code> value included as a parameter.<a href="#section-2.5-2" class="pilcrow">¶</a></p>
+<p id="section-2.5-3">The following is a non-normative example of a response from the token endpoint, whereby the <code>access_token</code> authorizes the Holder to request a <code>credential</code> from the credential endpoint.<a href="#section-2.5-3" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-2.5-4">
+<pre>{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ",
+  "token_type": "bearer",
+  "expires_in": 86400,
+  "id_token": "eyJodHRwOi8vbWF0dHIvdGVuYW50L..3Mz"
+}
+</pre><a href="#section-2.5-4" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="credential-endpoint">
+<section id="section-3">
+      <h2 id="name-credential-endpoint">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-credential-endpoint" class="section-name selfRef">Credential Endpoint</a>
+      </h2>
+<p id="section-3-1">The credential endpoint is used by a Holder to request the issuance of a verifiable credential from a Credential Provder (OP).<a href="#section-3-1" class="pilcrow">¶</a></p>
+<p id="section-3-2">The Holder MUST use the <code>access_token</code> previously acquired in the token endpoint response from the Credential Provider as an authorization header.  It is recommended that the <code>access_token</code> be sender constrained (Note: do we require this or leave as optional based on the Credential Provider's preference, to provide a DPoP example).<a href="#section-3-2" class="pilcrow">¶</a></p>
+<div id="credential-endpoint-request-parameters">
+<section id="section-3.1">
+        <h3 id="name-credential-endpoint-request">
+<a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-credential-endpoint-request" class="section-name selfRef">Credential Endpoint Request Parameters</a>
+        </h3>
+<p id="section-3.1-1">The Holder may provide a signed request object containing the <code>sub</code> to be used as the subject for the resulting credential.  When a <code>sub</code> claim is present within the request object an associated <code>sub_jwk</code> claim MUST also be present of which the request object MUST be signed with, therefore proving control over the <code>sub</code>.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
+<p id="section-3.1-2">The Holder may also specify the <code>credential_format</code> they wish the credential to be returned in, given it is supported by the Credential Provider. If not specified or not supported the Credential Provider will use their preferred default format.<a href="#section-3.1-2" class="pilcrow">¶</a></p>
+<p id="section-3.1-3">When a signed request is not provided the Credential Provider will use the <code>sub</code> associated with the initial <code>auth</code> request, where possible.  If a <code>sub</code> value is not available an error should be returned by the Credential Provider.<a href="#section-3.1-3" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-3.1-4">
+          <dt id="section-3.1-4.1">request</dt>
+<dd id="section-3.1-4.2">
+            <p id="section-3.1-4.2.1">OPTIONAL. A valid OIDC signed JWT request object. The request object is used to provide a <code>sub</code> the Holder wishes to be used as the subject of the resulting credential as well as provide proof of control of that <code>sub</code>.<a href="#section-3.1-4.2.1" class="pilcrow">¶</a></p>
+</dd>
+</dl>
+<p id="section-3.1-5">A non-normative example of a Signed Credential request.<a href="#section-3.1-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.1-6">
+<pre>POST /credential HTTP/1.1
+Host: https://issuer.example.com
+Authorization: Bearer &lt;access-token&gt;
+  request=&lt;signed-jwt-request-obj&gt;
+</pre><a href="#section-3.1-6" class="pilcrow">¶</a>
+</div>
+<p id="section-3.1-7">Where the decoded payload of the request parameter is as follows:<a href="#section-3.1-7" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.1-8">
+<pre>{
+  "aud": "https://issuer.example.com",
+  "iss": "https://wallet.example.com",
+  "sub": "urn:uuid:dc000c79-6aa3-45f2-9527-43747d5962a5",
+  "sub_jwk" : {
+    "crv":"secp256k1",
+    "kid":"YkDpvGNsch2lFBf6p8u3",
+    "kty":"EC",
+    "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
+    "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
+  },
+  "credential_format": "w3cvc-jwt",
+  "nonce": "43747d5962a5",
+  "iat": 1591069056,
+  "exp": 1591069556
+}
+</pre><a href="#section-3.1-8" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
 </section>
 </div>
 <div id="credential-response">
-<section id="section-3">
+<section id="section-4">
       <h2 id="name-credential-response">
-<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-credential-response" class="section-name selfRef">Credential Response</a>
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-credential-response" class="section-name selfRef">Credential Response</a>
       </h2>
+<div class="artwork art-text alignLeft" id="section-4-1">
+<pre>{
+  "credential": &lt;credential&gt;
+}
+</pre><a href="#section-4-1" class="pilcrow">¶</a>
+</div>
 <div id="credential">
-<section id="section-3.1">
+<section id="section-4.1">
         <h3 id="name-credential">
-<a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-credential" class="section-name selfRef">Credential</a>
+<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-credential" class="section-name selfRef">Credential</a>
         </h3>
-<p id="section-3.1-1">Formats of the Credential can vary, examples include JSON-LD or JWT based Credentials, the OpenID provider SHOULD make the supported credential formats available at their openid-configuration meta-data endpoint.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
-<p id="section-3.1-2">The following is a non-normative example of a Credential issued as a <a href="https://www.w3.org/TR/vc-data-model/">W3C Verifiable Credential 1.0</a> compliant format in JSON-LD.<a href="#section-3.1-2" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.1-3">
+<p id="section-4.1-1">Formats of the <code>credential</code> can vary, examples include JSON-LD or JWT based Credentials, the OpenID provider SHOULD make the supported credential formats available at their openid-configuration meta-data endpoint.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
+<p id="section-4.1-2">The following is a non-normative example of a Credential issued as a <a href="https://www.w3.org/TR/vc-data-model/">W3C Verifiable Credential 1.0</a> compliant format in JSON-LD.<a href="#section-4.1-2" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-4.1-3">
 <pre>{
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1423,7 +1506,7 @@ Location: https://server.example.com/authorize?
   "issuer": "did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd",
   "issuanceDate": "2020-03-10T04:24:12.164Z",
   "credentialSubject": {
-    "id": "123456789",
+    "id": "urn:uuid:dc000c79-6aa3-45f2-9527-43747d5962a5",
     "jwk": {
       "crv":"secp256k1",
       "kid":"YkDpvGNsch2lFBf6p8u3",
@@ -1446,18 +1529,18 @@ Location: https://server.example.com/authorize?
     "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..l9d0YHjcFAH2H4dB9xlWFZQLUpixVCWJk0eOt4CXQe1NXKWZwmhmn9OQp6YxX0a2LffegtYESTCJEoGVXLqWAA"
   }
 }
-</pre><a href="#section-3.1-3" class="pilcrow">¶</a>
+</pre><a href="#section-4.1-3" class="pilcrow">¶</a>
 </div>
-<p id="section-3.1-4">The following is a non-normative example of a Credential issued as a <a href="https://tools.ietf.org/html/rfc7519">JWT</a><a href="#section-3.1-4" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.1-5">
+<p id="section-4.1-4">The following is a non-normative example of a Credential issued as a <a href="https://tools.ietf.org/html/rfc7519">JWT</a><a href="#section-4.1-4" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-4.1-5">
 <pre>ewogICJhbGciOiAiRVMyNTYiLAogICJ0eXAiOiAiSldUIgp9.ewogICJpc3MiOiAiaXNzdWVyIjogImh0dHBzOi8vaXNzdWVyLmVkdSIsCiAgInN1YiI6ICJkaWQ6ZXhhbXBsZToxMjM0NTYiLAogICJpYXQiOiAxNTkxMDY5MDU2LAogICJleHAiOiAxNTkxMDY5NTU2LAogICJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy9leGFtcGxlcy92MS9kZWdyZWUiOiB7CiAgICAgImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxL3R5cGUiOiAiQmFjaGVsb3JEZWdyZWUiLAogICAgICJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy9leGFtcGxlcy92MS9uYW1lIjogIkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiCiAgfQp9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
-</pre><a href="#section-3.1-5" class="pilcrow">¶</a>
+</pre><a href="#section-4.1-5" class="pilcrow">¶</a>
 </div>
-<p id="section-3.1-6">And the decoded Claim Set of the JWT<a href="#section-3.1-6" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.1-7">
+<p id="section-4.1-6">And the decoded Claim Set of the JWT<a href="#section-4.1-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-4.1-7">
 <pre>{
-  "iss": "issuer": "https://issuer.edu",
-  "sub": "123456789",
+  "iss": "https://issuer.example.com",
+  "sub": "urn:uuid:dc000c79-6aa3-45f2-9527-43747d5962a5",
   "sub_jwk" : {
     "crv":"secp256k1",
     "kid":"YkDpvGNsch2lFBf6p8u3",
@@ -1467,52 +1550,29 @@ Location: https://server.example.com/authorize?
   },
   "iat": 1591069056,
   "exp": 1591069556,
-  "https://www.w3.org/2018/credentials/examples/v1/degree": {
-     "https://www.w3.org/2018/credentials/examples/v1/type": "BachelorDegree",
-     "https://www.w3.org/2018/credentials/examples/v1/name": "Bachelor of Science and Arts"
+  "vc": {
+    "credentialSubject": {
+      "https://www.w3.org/2018/credentials/examples/v1/degree": {
+        "https://www.w3.org/2018/credentials/examples/v1/type": "BachelorDegree",
+        "https://www.w3.org/2018/credentials/examples/v1/name": "Bachelor of Science and Arts"
+      }
+    }
   }
 }
-</pre><a href="#section-3.1-7" class="pilcrow">¶</a>
+</pre><a href="#section-4.1-7" class="pilcrow">¶</a>
 </div>
-</section>
-</div>
-<div id="token-endpoint-response">
-<section id="section-3.2">
-        <h3 id="name-token-endpoint-response">
-<a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-token-endpoint-response" class="section-name selfRef">Token Endpoint Response</a>
-        </h3>
-<p id="section-3.2-1">Successful and Error Authentication Response are in the same manor as <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> with the <code>code</code> parameter always being returned with the Authorization Code Flow.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
-<p id="section-3.2-2">On Request to the Token Endpoint the <code>grant_type</code> value MUST be <code>authorization_code</code> inline with the Authorization Code Flow and the <code>code</code> value included as a parameter.<a href="#section-3.2-2" class="pilcrow">¶</a></p>
-<p id="section-3.2-3">The following is a non-normative example of a response from the token endpoint, whereby the <code>access_token</code> authorizes the Holder to request a <code>credential</code> from the credential endpoint.<a href="#section-3.2-3" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.2-4">
-<pre>{
-  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ",
-  "token_type": "bearer",
-  "expires_in": 86400,
-  "id_token": "eyJodHRwOi8vbWF0dHIvdGVuYW50L..3Mz"
-}
-</pre><a href="#section-3.2-4" class="pilcrow">¶</a>
-</div>
-</section>
-</div>
-<div id="credential-endpoint">
-<section id="section-3.3">
-        <h3 id="name-credential-endpoint">
-<a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-credential-endpoint" class="section-name selfRef">Credential Endpoint</a>
-        </h3>
-<p id="section-3.3-1">TODO<a href="#section-3.3-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="token-endpoint-response-with-credential">
-<section id="section-3.4">
+<section id="section-4.2">
         <h3 id="name-token-endpoint-response-wit">
-<a href="#section-3.4" class="section-number selfRef">3.4. </a><a href="#name-token-endpoint-response-wit" class="section-name selfRef">Token Endpoint Response (with credential)</a>
+<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-token-endpoint-response-wit" class="section-name selfRef">Token Endpoint Response (with credential)</a>
         </h3>
-<p id="section-3.4-1">If the OpenID Connect request is a Signed Credential Request. The Response from the Token Endpoint MUST include the Credential in the form of an object with value for <code>format</code> indicating the credentials format and <code>data</code> containing the Credential.<a href="#section-3.4-1" class="pilcrow">¶</a></p>
-<p id="section-3.4-2">Successful and Error Authentication Response are in the same manor as <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> with the <code>code</code> parameter always being returned with the Authorization Code Flow.<a href="#section-3.4-2" class="pilcrow">¶</a></p>
-<p id="section-3.4-3">On Request to the Token Endpoint the <code>grant_type</code> value MUST be <code>authorization_code</code> inline with the Authorization Code Flow and the <code>code</code> value included as a parameter.<a href="#section-3.4-3" class="pilcrow">¶</a></p>
-<p id="section-3.4-4">The following is a non-normative example of a response from the token endpoint featuring a JSON-LD based Credential.<a href="#section-3.4-4" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.4-5">
+<p id="section-4.2-1">If the OpenID Connect request is a Signed Credential Request. The Response from the Token Endpoint MUST include the Credential in the form of an object with value for <code>format</code> indicating the credentials format and <code>data</code> containing the Credential.<a href="#section-4.2-1" class="pilcrow">¶</a></p>
+<p id="section-4.2-2">Successful and Error Authentication Response are in the same manor as <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a> with the <code>code</code> parameter always being returned with the Authorization Code Flow.<a href="#section-4.2-2" class="pilcrow">¶</a></p>
+<p id="section-4.2-3">On Request to the Token Endpoint the <code>grant_type</code> value MUST be <code>authorization_code</code> inline with the Authorization Code Flow and the <code>code</code> value included as a parameter.<a href="#section-4.2-3" class="pilcrow">¶</a></p>
+<p id="section-4.2-4">The following is a non-normative example of a response from the token endpoint featuring a JSON-LD based Credential.<a href="#section-4.2-4" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-4.2-5">
 <pre>{
   "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ",
   "token_type": "bearer",
@@ -1553,10 +1613,10 @@ Location: https://server.example.com/authorize?
     }
   }
 }
-</pre><a href="#section-3.4-5" class="pilcrow">¶</a>
+</pre><a href="#section-4.2-5" class="pilcrow">¶</a>
 </div>
-<p id="section-3.4-6">The following is a non-normative example of a response from the token endpoint featuring a JWT based credential<a href="#section-3.4-6" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.4-7">
+<p id="section-4.2-6">The following is a non-normative example of a response from the token endpoint featuring a JWT based credential<a href="#section-4.2-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-4.2-7">
 <pre>{
   "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ",
   "token_type": "bearer",
@@ -1582,10 +1642,10 @@ Location: https://server.example.com/authorize?
           --7kLsyBAfQGbg"
   }
 }
-</pre><a href="#section-3.4-7" class="pilcrow">¶</a>
+</pre><a href="#section-4.2-7" class="pilcrow">¶</a>
 </div>
-<p id="section-3.4-8">And the decoded Claim Set of the JWT<a href="#section-3.4-8" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.4-9">
+<p id="section-4.2-8">And the decoded Claim Set of the JWT<a href="#section-4.2-8" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-4.2-9">
 <pre>{
   "iss": "issuer": "https://issuer.edu",
   "sub": "123456789",
@@ -1614,41 +1674,41 @@ Location: https://server.example.com/authorize?
     }
   }
 }
-</pre><a href="#section-3.4-9" class="pilcrow">¶</a>
+</pre><a href="#section-4.2-9" class="pilcrow">¶</a>
 </div>
 </section>
 </div>
 </section>
 </div>
 <div id="usage-of-decentralized-identifiers">
-<section id="section-4">
+<section id="section-5">
       <h2 id="name-usage-of-decentralized-iden">
-<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-usage-of-decentralized-iden" class="section-name selfRef">Usage of Decentralized Identifiers</a>
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-usage-of-decentralized-iden" class="section-name selfRef">Usage of Decentralized Identifiers</a>
       </h2>
-<p id="section-4-1"><a href="https://w3c.github.io/did-core/">Decentralized identifiers</a> are a resolvable identifier to a set of statements about the <a href="https://w3c.github.io/did-core/#dfn-did-subjects">did subject</a> including a set of cryptographic material (e.g public keys). Using this cryptographic material, a <a href="https://w3c.github.io/did-core/">decentralized identifier</a> can be used as an authenticatable identifier in a credential, rather than using a public key directly.<a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-5-1"><a href="https://w3c.github.io/did-core/">Decentralized identifiers</a> are a resolvable identifier to a set of statements about the <a href="https://w3c.github.io/did-core/#dfn-did-subjects">did subject</a> including a set of cryptographic material (e.g public keys). Using this cryptographic material, a <a href="https://w3c.github.io/did-core/">decentralized identifier</a> can be used as an authenticatable identifier in a credential, rather than using a public key directly.<a href="#section-5-1" class="pilcrow">¶</a></p>
 <div id="signed-credential-request-using-a-decentralized-identifier">
-<section id="section-4.1">
+<section id="section-5.1">
         <h3 id="name-signed-credential-request-u">
-<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-signed-credential-request-u" class="section-name selfRef">Signed Credential Request using a Decentralized Identifier</a>
+<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-signed-credential-request-u" class="section-name selfRef">Signed Credential Request using a Decentralized Identifier</a>
         </h3>
-<p id="section-4.1-1">A Holder submitting a signed Credential Request can request, that the resulting credential be bound to the Holder through the usage of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a> by using the <code>did</code> field.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
-<p id="section-4.1-2">A Holder prior to submitting a credential request SHOULD validate that the Credential Provider supports the resolution of decentralized identifiers by retrieving their openid-configuration metadata to check if an attribute of <code>dids_supported</code> has a value of <code>true</code>.<a href="#section-4.1-2" class="pilcrow">¶</a></p>
-<p id="section-4.1-3">The Holder SHOULD also validate that the Credential Provider supports the <a href="https://w3c-ccg.github.io/did-method-registry/">did method</a> to be used in the request by retrieving their openid-configuration metadata to check if an attribute of <code>did_methods_supported</code> contains the required did method.<a href="#section-4.1-3" class="pilcrow">¶</a></p>
-<p id="section-4.1-4">A Credential Provider processing a credential request featuring a <a href="https://w3c.github.io/did-core/">decentralized identifier</a> MUST follow the following additional steps to validate the request.<a href="#section-4.1-4" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-4.1-5">
-          <li id="section-4.1-5.1">
-            <p id="section-4.1-5.1.1">Validate the value in the <code>did</code> field is a valid <a href="https://w3c.github.io/did-core/">decentralized identifier</a>.<a href="#section-4.1-5.1.1" class="pilcrow">¶</a></p>
+<p id="section-5.1-1">A Holder submitting a signed Credential Request can request, that the resulting credential be bound to the Holder through the usage of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a> by using the <code>did</code> field.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
+<p id="section-5.1-2">A Holder prior to submitting a credential request SHOULD validate that the Credential Provider supports the resolution of decentralized identifiers by retrieving their openid-configuration metadata to check if an attribute of <code>dids_supported</code> has a value of <code>true</code>.<a href="#section-5.1-2" class="pilcrow">¶</a></p>
+<p id="section-5.1-3">The Holder SHOULD also validate that the Credential Provider supports the <a href="https://w3c-ccg.github.io/did-method-registry/">did method</a> to be used in the request by retrieving their openid-configuration metadata to check if an attribute of <code>did_methods_supported</code> contains the required did method.<a href="#section-5.1-3" class="pilcrow">¶</a></p>
+<p id="section-5.1-4">A Credential Provider processing a credential request featuring a <a href="https://w3c.github.io/did-core/">decentralized identifier</a> MUST follow the following additional steps to validate the request.<a href="#section-5.1-4" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-5.1-5">
+          <li id="section-5.1-5.1">
+            <p id="section-5.1-5.1.1">Validate the value in the <code>did</code> field is a valid <a href="https://w3c.github.io/did-core/">decentralized identifier</a>.<a href="#section-5.1-5.1.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-4.1-5.2">
-            <p id="section-4.1-5.2.1">Resolve this the <code>did</code> value to a <a href="https://w3c.github.io/did-core/#dfn-did-documents">did document</a>.<a href="#section-4.1-5.2.1" class="pilcrow">¶</a></p>
+<li id="section-5.1-5.2">
+            <p id="section-5.1-5.2.1">Resolve this the <code>did</code> value to a <a href="https://w3c.github.io/did-core/#dfn-did-documents">did document</a>.<a href="#section-5.1-5.2.1" class="pilcrow">¶</a></p>
 </li>
-<li id="section-4.1-5.3">
-            <p id="section-4.1-5.3.1">Validate that the key in the <code>sub_jwk</code> field of the request is referenced in the <a href="https://w3c.github.io/did-core/#authentication">authentication</a> section of the <a href="https://w3c.github.io/did-core/#dfn-did-documents">DID Document</a>.<a href="#section-4.1-5.3.1" class="pilcrow">¶</a></p>
+<li id="section-5.1-5.3">
+            <p id="section-5.1-5.3.1">Validate that the key in the <code>sub_jwk</code> field of the request is referenced in the <a href="https://w3c.github.io/did-core/#authentication">authentication</a> section of the <a href="https://w3c.github.io/did-core/#dfn-did-documents">DID Document</a>.<a href="#section-5.1-5.3.1" class="pilcrow">¶</a></p>
 </li>
 </ol>
-<p id="section-4.1-6">If any of the steps fail then the OpenID Provider MUST respond to the request with the Error Response parameter, <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthError">section 3.1.2.6.</a> with Error code: <code>invalid_did</code>.<a href="#section-4.1-6" class="pilcrow">¶</a></p>
-<p id="section-4.1-7">The following is a non-normative example of requesting the issuance of a credential that uses a decentralized identifier.<a href="#section-4.1-7" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-4.1-8">
+<p id="section-5.1-6">If any of the steps fail then the OpenID Provider MUST respond to the request with the Error Response parameter, <a href="https://openid.net/specs/openid-connect-core-1_0.html#AuthError">section 3.1.2.6.</a> with Error code: <code>invalid_did</code>.<a href="#section-5.1-6" class="pilcrow">¶</a></p>
+<p id="section-5.1-7">The following is a non-normative example of requesting the issuance of a credential that uses a decentralized identifier.<a href="#section-5.1-7" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-5.1-8">
 <pre>{
   "response_type": "code",
   "client_id": "IAicV0pt9co5nn9D1tUKDCoPQq8BFlGH",
@@ -1664,10 +1724,10 @@ Location: https://server.example.com/authorize?
   "credential_format": "w3cvc-jsonld"
 
 }
-</pre><a href="#section-4.1-8" class="pilcrow">¶</a>
+</pre><a href="#section-5.1-8" class="pilcrow">¶</a>
 </div>
-<p id="section-4.1-9">The following is a non-normative example of a token endpoint response for the request shown above.<a href="#section-4.1-9" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-4.1-10">
+<p id="section-5.1-9">The following is a non-normative example of a token endpoint response for the request shown above.<a href="#section-5.1-9" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-5.1-10">
 <pre>{
   "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ",
   "token_type": "bearer",
@@ -1701,46 +1761,46 @@ Location: https://server.example.com/authorize?
     }
   }
 }
-</pre><a href="#section-4.1-10" class="pilcrow">¶</a>
+</pre><a href="#section-5.1-10" class="pilcrow">¶</a>
 </div>
 </section>
 </div>
 </section>
 </div>
 <div id="openid-provider-metadata">
-<section id="section-5">
+<section id="section-6">
       <h2 id="name-openid-provider-metadata">
-<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-openid-provider-metadata" class="section-name selfRef">OpenID Provider Metadata</a>
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-openid-provider-metadata" class="section-name selfRef">OpenID Provider Metadata</a>
       </h2>
-<p id="section-5-1">An OpenID provider can use the following meta-data elements to advertise its support for credential issuance in its openid-configuration defined by <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID-Discovery</a>.<a href="#section-5-1" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-5-2">
-        <dt id="section-5-2.1"><code>credential_supported</code></dt>
-<dd id="section-5-2.2">
-          <p id="section-5-2.2.1">Boolean value indicating that the OpenID provider supports the credential issuance flow.<a href="#section-5-2.2.1" class="pilcrow">¶</a></p>
+<p id="section-6-1">An OpenID provider can use the following meta-data elements to advertise its support for credential issuance in its openid-configuration defined by <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID-Discovery</a>.<a href="#section-6-1" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-6-2">
+        <dt id="section-6-2.1"><code>credential_supported</code></dt>
+<dd id="section-6-2.2">
+          <p id="section-6-2.2.1">Boolean value indicating that the OpenID provider supports the credential issuance flow.<a href="#section-6-2.2.1" class="pilcrow">¶</a></p>
 </dd>
-<dt id="section-5-2.3"><code>credential_formats_supported</code></dt>
-<dd id="section-5-2.4">
-          <p id="section-5-2.4.1">A JSON array of strings identifying the resulting format of the credential issued at the end of the flow.<a href="#section-5-2.4.1" class="pilcrow">¶</a></p>
+<dt id="section-6-2.3"><code>credential_formats_supported</code></dt>
+<dd id="section-6-2.4">
+          <p id="section-6-2.4.1">A JSON array of strings identifying the resulting format of the credential issued at the end of the flow.<a href="#section-6-2.4.1" class="pilcrow">¶</a></p>
 </dd>
-<dt id="section-5-2.5"><code>credential_claims_supported</code></dt>
-<dd id="section-5-2.6">
-          <p id="section-5-2.6.1">A JSON array of strings identifying the claim names supported within an issued credential.<a href="#section-5-2.6.1" class="pilcrow">¶</a></p>
+<dt id="section-6-2.5"><code>credential_claims_supported</code></dt>
+<dd id="section-6-2.6">
+          <p id="section-6-2.6.1">A JSON array of strings identifying the claim names supported within an issued credential.<a href="#section-6-2.6.1" class="pilcrow">¶</a></p>
 </dd>
-<dt id="section-5-2.7"><code>credential_name</code></dt>
-<dd id="section-5-2.8">
-          <p id="section-5-2.8.1">A human readable string to identify the name of the credential offered by the provider.<a href="#section-5-2.8.1" class="pilcrow">¶</a></p>
+<dt id="section-6-2.7"><code>credential_name</code></dt>
+<dd id="section-6-2.8">
+          <p id="section-6-2.8.1">A human readable string to identify the name of the credential offered by the provider.<a href="#section-6-2.8.1" class="pilcrow">¶</a></p>
 </dd>
-<dt id="section-5-2.9"><code>dids_supported</code></dt>
-<dd id="section-5-2.10">
-          <p id="section-5-2.10.1">Boolean value indicating that the OpenID provider supports the resolution of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a>.<a href="#section-5-2.10.1" class="pilcrow">¶</a></p>
+<dt id="section-6-2.9"><code>dids_supported</code></dt>
+<dd id="section-6-2.10">
+          <p id="section-6-2.10.1">Boolean value indicating that the OpenID provider supports the resolution of <a href="https://w3c.github.io/did-core/">decentralized identifiers</a>.<a href="#section-6-2.10.1" class="pilcrow">¶</a></p>
 </dd>
-<dt id="section-5-2.11"><code>did_methods_supported</code></dt>
-<dd id="section-5-2.12">
-          <p id="section-5-2.12.1">A JSON array of strings representing <a href="https://w3c-ccg.github.io/did-method-registry/">Decentralized Identifier Methods</a> that the OpenID provider supports resolution of.<a href="#section-5-2.12.1" class="pilcrow">¶</a></p>
+<dt id="section-6-2.11"><code>did_methods_supported</code></dt>
+<dd id="section-6-2.12">
+          <p id="section-6-2.12.1">A JSON array of strings representing <a href="https://w3c-ccg.github.io/did-method-registry/">Decentralized Identifier Methods</a> that the OpenID provider supports resolution of.<a href="#section-6-2.12.1" class="pilcrow">¶</a></p>
 </dd>
 </dl>
-<p id="section-5-3">The following is a non-normative example of the relevant entries in the openid-configuration meta data for an OpenID Provider supporting the credential issuance flow<a href="#section-5-3" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-5-4">
+<p id="section-6-3">The following is a non-normative example of the relevant entries in the openid-configuration meta data for an OpenID Provider supporting the credential issuance flow<a href="#section-6-3" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-6-4">
 <pre>{
   "dids_supported": true,
   "did_methods_supported": [
@@ -1760,22 +1820,22 @@ Location: https://server.example.com/authorize?
   ],
   "credential_name": "University Credential"
 }
-</pre><a href="#section-5-4" class="pilcrow">¶</a>
+</pre><a href="#section-6-4" class="pilcrow">¶</a>
 </div>
 <div id="url-construction">
-<section id="section-5.1">
+<section id="section-6.1">
         <h3 id="name-url-construction">
-<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-url-construction" class="section-name selfRef">URL Construction</a>
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-url-construction" class="section-name selfRef">URL Construction</a>
         </h3>
-<p id="section-5.1-1">In certain instances it is advantageous to be able to construct a URL which points at an OpenID Connect provider, of which is invocable by a supporting OpenID Connect client.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
-<p id="section-5.1-2">The URL SHOULD use the scheme <code>openid</code> to allow supporting clients to register intent to handle the URL.<a href="#section-5.1-2" class="pilcrow">¶</a></p>
-<p id="section-5.1-3">The URL SHOULD feature the term <code>discovery</code> in the host portion of the URL identifying the intent of the URL is to communicate discovery related information.<a href="#section-5.1-3" class="pilcrow">¶</a></p>
-<p id="section-5.1-4">The URL SHOULD feature a query parameter with key <code>issuer</code> who's value corresponds to a valid issuer identifier as defined in <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID Connect Discovery</a>. This identifier MUST be a url of the scheme <code>https://</code> of which when concatenated with the string <code>/.well-known/openid-configuration</code> and dereferenced by an HTTP GET request
-results in the retrieval of the providers OpenID Connect Metadata.<a href="#section-5.1-4" class="pilcrow">¶</a></p>
-<p id="section-5.1-5">The following is a non-normative example of an invocable URL pointing to the OpenID Provider who has the issuer identifier of <code>https://issuer.example.com</code><a href="#section-5.1-5" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-5.1-6">
+<p id="section-6.1-1">In certain instances it is advantageous to be able to construct a URL which points at an OpenID Connect provider, of which is invocable by a supporting OpenID Connect client.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.1-2">The URL SHOULD use the scheme <code>openid</code> to allow supporting clients to register intent to handle the URL.<a href="#section-6.1-2" class="pilcrow">¶</a></p>
+<p id="section-6.1-3">The URL SHOULD feature the term <code>discovery</code> in the host portion of the URL identifying the intent of the URL is to communicate discovery related information.<a href="#section-6.1-3" class="pilcrow">¶</a></p>
+<p id="section-6.1-4">The URL SHOULD feature a query parameter with key <code>issuer</code> who's value corresponds to a valid issuer identifier as defined in <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID Connect Discovery</a>. This identifier MUST be a url of the scheme <code>https://</code> of which when concatenated with the string <code>/.well-known/openid-configuration</code> and dereferenced by an HTTP GET request
+results in the retrieval of the providers OpenID Connect Metadata.<a href="#section-6.1-4" class="pilcrow">¶</a></p>
+<p id="section-6.1-5">The following is a non-normative example of an invocable URL pointing to the OpenID Provider who has the issuer identifier of <code>https://issuer.example.com</code><a href="#section-6.1-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-6.1-6">
 <pre>openid://discovery?issuer=https://issuer.example.com
-</pre><a href="#section-5.1-6" class="pilcrow">¶</a>
+</pre><a href="#section-6.1-6" class="pilcrow">¶</a>
 </div>
 </section>
 </div>

--- a/spec.md
+++ b/spec.md
@@ -267,7 +267,7 @@ The Holder may provide a signed request object containing the `sub` to be used a
 
 The Holder may also specify the `credential_format` they wish the returned credential to be formatted as. If the provider receiving the request does not support the requested credential format they it MUST return an error response, as per [TODO]. If the credential_format is not specified in the request SHOULD respond with their preferred or default format. (Note if we are going to have a default we need to specify it or is it at the discretion of the provider to determine this?)
 
-When a signed request is not provided the Credential Provider will use the `sub` associated with the initial `auth` request, where possible.  If a `sub` value is not available an error should be returned by the Credential Provider.
+When a signed request is not provided the Credential Provider will use the `sub` associated with the initial `auth` request, where possible.  If a `sub` value is not available the provider MUST return an error response, as per [TODO].
 
 request
 : OPTIONAL. A valid OIDC signed JWT request object. The request object is used to provide a `sub` the Holder wishes to be used as the subject of the resulting credential as well as provide proof of control of that `sub`.

--- a/spec.md
+++ b/spec.md
@@ -265,7 +265,7 @@ The Credential Endpoint SHOULD support the use of Cross Origin Resource Sharing 
 
 The Holder may provide a signed request object containing the `sub` to be used as the subject for the resulting credential.  When a `sub` claim is present within the request object an associated `sub_jwk` claim MUST also be present of which the request object MUST be signed with, therefore proving control over the `sub`.
 
-The Holder may also specify the `credential_format` they wish the credential to be returned in, given it is supported by the Credential Provider. If not specified or not supported the Credential Provider will use their preferred default format. (Note if we are going to have a default we need to specify it)
+The Holder may also specify the `credential_format` they wish the returned credential to be formatted as. If the provider receiving the request does not support the requested credential format they it MUST return an error response, as per [TODO]. If the credential_format is not specified in the request SHOULD respond with their preferred or default format. (Note if we are going to have a default we need to specify it or is it at the discretion of the provider to determine this?)
 
 When a signed request is not provided the Credential Provider will use the `sub` associated with the initial `auth` request, where possible.  If a `sub` value is not available an error should be returned by the Credential Provider.
 

--- a/spec.md
+++ b/spec.md
@@ -293,7 +293,7 @@ Successful and Error Authentication Response are in the same manor as [OpenID Co
 
 On Request to the Token Endpoint the `grant_type` value MUST be `authorization_code` inline with the Authorization Code Flow and the `code` value included as a parameter.
 
-The following is a non-normative example of a response from the token endpoint. The novelty being that the returned `access_token` may now be used at the `credential` endpoint.
+The following is a non-normative example of a response from the token endpoint, whereby the `access_token` authorizes the Holder to request a `credential` from the credential endpoint.
 
 ```
 {

--- a/spec.md
+++ b/spec.md
@@ -242,7 +242,6 @@ It is recommended that the Credential Endpoint SHOULD enforce presentation of th
 
 The Credential Endpoint SHOULD support the use of Cross Origin Resource Sharing (CORS) [CORS] and or other methods as appropriate to enable Java Script Clients to access the endpoint.
 
-The Holder MUST use the `access_token` previously acquired in the token endpoint response from the Credential Provider as an authorization header.  It is recommended that the `access_token` be sender constrained (Note: do we require this or leave as optional based on the Credential Provider's preference, to provide a DPoP example).
 
 ## Credential Endpoint Request Parameters
 

--- a/spec.md
+++ b/spec.md
@@ -232,7 +232,15 @@ The following is a non-normative example of a response from the token endpoint, 
 ```
 # Credential Endpoint
 
-The credential endpoint is used by a Holder to request the issuance of a verifiable credential from a Credential Provder (OP).
+The Credential Endpoint is an OAuth 2.0 Protected Resource that when called, returns Claims about the authenticated End-User in the form of a credential. To obtain the requested Claims about the End-User, the Client makes a request to the UserInfo Endpoint using an Access Token obtained through OpenID Connect Authentication whereby the the `openid_credential` scope was granted.
+
+Communication with the Credential Endpoint MUST utilize TLS. See Section 16.17 for more information on using TLS.
+
+The Credential Endpoint MUST support the use of HTTP POST methods defined in RFC 2616 [RFC2616].
+
+It is recommended that the Credential Endpoint SHOULD enforce presentation of the OAuth2.0 Access Token to be sender constrained [DPOP](https://tools.ietf.org/html/draft-fett-oauth-dpop-04). However the Credential Endpoint MUST also accept Access Tokens as OAuth 2.0 Bearer Token Usage [RFC6750]. (Note: do we remove?)
+
+The Credential Endpoint SHOULD support the use of Cross Origin Resource Sharing (CORS) [CORS] and or other methods as appropriate to enable Java Script Clients to access the endpoint.
 
 The Holder MUST use the `access_token` previously acquired in the token endpoint response from the Credential Provider as an authorization header.  It is recommended that the `access_token` be sender constrained (Note: do we require this or leave as optional based on the Credential Provider's preference, to provide a DPoP example).
 

--- a/spec.md
+++ b/spec.md
@@ -347,13 +347,9 @@ And the decoded Claim Set of the JWT
   },
   "iat": 1591069056,
   "exp": 1591069556,
-  "vc": {
-    "credentialSubject": {
-      "https://www.w3.org/2018/credentials/examples/v1/degree": {
-        "https://www.w3.org/2018/credentials/examples/v1/type": "BachelorDegree",
-        "https://www.w3.org/2018/credentials/examples/v1/name": "Bachelor of Science and Arts"
-      }
-    }
+  "https://www.w3.org/2018/credentials/examples/v1/degree": {
+    "https://www.w3.org/2018/credentials/examples/v1/type": "BachelorDegree",
+    "https://www.w3.org/2018/credentials/examples/v1/name": "Bachelor of Science and Arts"
   }
 }
 ```

--- a/spec.md
+++ b/spec.md
@@ -247,7 +247,7 @@ The Credential Endpoint SHOULD support the use of Cross Origin Resource Sharing 
 
 The Holder may provide a signed request object containing the `sub` to be used as the subject for the resulting credential.  When a `sub` claim is present within the request object an associated `sub_jwk` claim MUST also be present of which the request object MUST be signed with, therefore proving control over the `sub`.
 
-The Holder may also specify the `credential_format` they wish the credential to be returned in, given it is supported by the Credential Provider. If not specified or not supported the Credential Provider will use their preferred default format.
+The Holder may also specify the `credential_format` they wish the credential to be returned in, given it is supported by the Credential Provider. If not specified or not supported the Credential Provider will use their preferred default format. (Note if we are going to have a default we need to specify it)
 
 When a signed request is not provided the Credential Provider will use the `sub` associated with the initial `auth` request, where possible.  If a `sub` value is not available an error should be returned by the Credential Provider.
 

--- a/spec.md
+++ b/spec.md
@@ -287,6 +287,23 @@ And the decoded Claim Set of the JWT
 }
 ```
 
+## Token Endpoint Response
+
+Successful and Error Authentication Response are in the same manor as [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) with the `code` parameter always being returned with the Authorization Code Flow.
+
+On Request to the Token Endpoint the `grant_type` value MUST be `authorization_code` inline with the Authorization Code Flow and the `code` value included as a parameter.
+
+The following is a non-normative example of a response from the token endpoint. The novelty being that the returned `access_token` may now be used at the `credential` endpoint.
+
+```
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ",
+  "token_type": "bearer",
+  "expires_in": 86400,
+  "id_token": "eyJodHRwOi8vbWF0dHIvdGVuYW50L..3Mz"
+}
+```
+
 ## Credential Endpoint
 
 TODO

--- a/spec.md
+++ b/spec.md
@@ -260,7 +260,10 @@ A non-normative example of a Signed Credential request.
 POST /credential HTTP/1.1
 Host: https://issuer.example.com
 Authorization: Bearer <access-token>
-  request=<signed-jwt-request-obj>
+Content-Type: application/json
+{
+  "request": <signed-jwt-request-obj>
+}
 ```
 
 Where the decoded payload of the request parameter is as follows:

--- a/spec.md
+++ b/spec.md
@@ -250,7 +250,7 @@ The following is a non-normative example of a response from the token endpoint, 
 ```
 # Credential Endpoint
 
-The Credential Endpoint is an OAuth 2.0 Protected Resource that when called, returns Claims about the authenticated End-User in the form of a credential. To obtain the requested Claims about the End-User, the Client makes a request to the UserInfo Endpoint using an Access Token obtained through OpenID Connect Authentication whereby the the `openid_credential` scope was granted.
+The Credential Endpoint is an OAuth 2.0 Protected Resource that when called, returns Claims about the authenticated End-User in the form of a credential. To obtain a credential on behalf of the End-User, the Client makes a request to the Credential Endpoint using an Access Token obtained through OpenID Connect Authentication whereby the the `openid_credential` scope was granted.
 
 Communication with the Credential Endpoint MUST utilize TLS. See Section 16.17 for more information on using TLS.
 


### PR DESCRIPTION
Minimal draft of the credential endpoint, omitting sender constrained access token, noted as todo
Pulled the credential endpoint up to before the credential response is defined following the token endpoint response
Ref: #27