### PR TITLE
Added example of down scoped credential request. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1090,7 +1090,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">openid-credential-provider-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-04-02" class="published">2 April 2021</time>
+<time datetime="2021-04-06" class="published">6 April 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1469,8 +1469,8 @@ Content-Type: application/json
         <h3 id="name-down-scoped-credential-requ">
 <a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-down-scoped-credential-requ" class="section-name selfRef">Down Scoped Credential Request</a>
         </h3>
-<p id="section-3.2-1">The <code>claims</code> property may be used when requesting a Credential in order to reduce the claims returned by the CI.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
-<p id="section-3.2-2">The following is a non-normative example of the decoded payload of the request parameter of a down scoped Signed Credential request.<a href="#section-3.2-2" class="pilcrow">¶</a></p>
+<p id="section-3.2-1">The <code>claims</code> property, as inherited from <a href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">OIDC Core Section 5.5</a>, may be used by a holder when requesting a Credential from a CI in order to control the exact claims returned by the CI in the credential. When this parameter is not present the CI MUST return all the claims that are valid for the credential the holder is making a request for.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
+<p id="section-3.2-2">The following is a non-normative example of the decoded payload of the request making use of the claims parameter.<a href="#section-3.2-2" class="pilcrow">¶</a></p>
 <div class="artwork art-text alignLeft" id="section-3.2-3">
 <pre>{
   "aud": "https://issuer.example.com",

--- a/index.html
+++ b/index.html
@@ -1090,7 +1090,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">openid-credential-provider-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-04-01" class="published">1 April 2021</time>
+<time datetime="2021-04-02" class="published">2 April 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1164,6 +1164,9 @@ tr:nth-child(2n+1) > td {
 <ul class="toc ulEmpty">
 <li class="toc ulEmpty" id="section-toc.1-1.3.2.1">
                 <p id="section-toc.1-1.3.2.1.1"><a href="#section-3.1" class="xref">3.1</a>.  <a href="#name-credential-endpoint-request" class="xref">Credential Endpoint Request Parameters</a><a href="#section-toc.1-1.3.2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3.2.2">
+                <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="xref">3.2</a>.  <a href="#name-down-scoped-credential-requ" class="xref">Down Scoped Credential Request</a><a href="#section-toc.1-1.3.2.2.1" class="pilcrow">¶</a></p>
 </li>
 </ul>
 </li>
@@ -1420,15 +1423,16 @@ Location: https://server.example.com/authorize?
         </h3>
 <p id="section-3.1-1">The Holder may provide a signed request object containing the <code>sub</code> to be used as the subject for the resulting credential. When a <code>sub</code> claim is present within the request object an associated <code>sub_jwk</code> claim MUST also be present of which the request object MUST be signed with, therefore proving control over the <code>sub</code>.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
 <p id="section-3.1-2">The Holder may also specify the <code>credential_format</code> they wish the returned credential to be formatted as. If the CI receiving the request does not support the requested credential format they it MUST return an error response, as per [TODO]. If the <code>credential_format</code> is not specified in the request the CI SHOULD respond with their preferred or default format. (Note if we are going to have a default we need to specify it or is it at the discretion of the CI to determine this?)<a href="#section-3.1-2" class="pilcrow">¶</a></p>
-<p id="section-3.1-3">When a signed request is not provided the CI will use the <code>sub</code> associated with the initial Credential request, where possible. If a <code>sub</code> value is not available the CI MUST return an error response, as per [TODO].<a href="#section-3.1-3" class="pilcrow">¶</a></p>
-<dl class="dlParallel" id="section-3.1-4">
-          <dt id="section-3.1-4.1">request</dt>
-<dd id="section-3.1-4.2">
-            <p id="section-3.1-4.2.1">OPTIONAL. A valid OIDC signed JWT request object. The request object is used to provide a <code>sub</code> the Holder wishes to be used as the subject of the resulting credential as well as provide proof of control of that <code>sub</code>.<a href="#section-3.1-4.2.1" class="pilcrow">¶</a></p>
+<p id="section-3.1-3">The Holder may optionally choose to include a <code>claims</code> property within their request to down scope the set of claims returned. If not present the CI will return the complete set of claims.<a href="#section-3.1-3" class="pilcrow">¶</a></p>
+<p id="section-3.1-4">When a signed request is not provided the CI will use the <code>sub</code> associated with the initial Credential request, where possible. If a <code>sub</code> value is not available the CI MUST return an error response, as per [TODO].<a href="#section-3.1-4" class="pilcrow">¶</a></p>
+<dl class="dlParallel" id="section-3.1-5">
+          <dt id="section-3.1-5.1">request</dt>
+<dd id="section-3.1-5.2">
+            <p id="section-3.1-5.2.1">OPTIONAL. A valid OIDC signed JWT request object. The request object is used to provide a <code>sub</code> the Holder wishes to be used as the subject of the resulting credential as well as provide proof of control of that <code>sub</code>.<a href="#section-3.1-5.2.1" class="pilcrow">¶</a></p>
 </dd>
 </dl>
-<p id="section-3.1-5">A non-normative example of a Signed Credential request.<a href="#section-3.1-5" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.1-6">
+<p id="section-3.1-6">A non-normative example of a Signed Credential request.<a href="#section-3.1-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.1-7">
 <pre>POST /credential HTTP/1.1
 Host: https://issuer.example.com
 Authorization: Bearer &lt;access-token&gt;
@@ -1436,10 +1440,38 @@ Content-Type: application/json
 {
   "request": &lt;signed-jwt-request-obj&gt;
 }
-</pre><a href="#section-3.1-6" class="pilcrow">¶</a>
+</pre><a href="#section-3.1-7" class="pilcrow">¶</a>
 </div>
-<p id="section-3.1-7">Where the decoded payload of the request parameter is as follows:<a href="#section-3.1-7" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.1-8">
+<p id="section-3.1-8">Where the decoded payload of the request parameter is as follows:<a href="#section-3.1-8" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.1-9">
+<pre>{
+  "aud": "https://issuer.example.com",
+  "iss": "https://wallet.example.com",
+  "sub": "urn:uuid:dc000c79-6aa3-45f2-9527-43747d5962a5",
+  "sub_jwk" : {
+    "crv":"secp256k1",
+    "kid":"YkDpvGNsch2lFBf6p8u3",
+    "kty":"EC",
+    "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
+    "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
+  },
+  "credential_format": "w3cvc-jsonld",
+  "nonce": "43747d5962a5",
+  "iat": 1591069056,
+  "exp": 1591069556
+}
+</pre><a href="#section-3.1-9" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+<div id="down-scoped-credential-request">
+<section id="section-3.2">
+        <h3 id="name-down-scoped-credential-requ">
+<a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-down-scoped-credential-requ" class="section-name selfRef">Down Scoped Credential Request</a>
+        </h3>
+<p id="section-3.2-1">The <code>claims</code> property may be used when requesting a Credential in order to reduce the claims returned by the CI.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
+<p id="section-3.2-2">The following is a non-normative example of the decoded payload of the request parameter of a down scoped Signed Credential request.<a href="#section-3.2-2" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.2-3">
 <pre>{
   "aud": "https://issuer.example.com",
   "iss": "https://wallet.example.com",
@@ -1454,9 +1486,14 @@ Content-Type: application/json
   "credential_format": "w3cvc-jwt",
   "nonce": "43747d5962a5",
   "iat": 1591069056,
-  "exp": 1591069556
+  "exp": 1591069556,
+  "claims": {
+    "nickname": null,
+    "familyName": { "essential": true }
+    "degree": { "essential": true }
+  }
 }
-</pre><a href="#section-3.1-8" class="pilcrow">¶</a>
+</pre><a href="#section-3.2-3" class="pilcrow">¶</a>
 </div>
 </section>
 </div>

--- a/index.html
+++ b/index.html
@@ -1090,7 +1090,7 @@ tr:nth-child(2n+1) > td {
 <dd class="individual-draft">openid-credential-provider-01</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-04-06" class="published">6 April 2021</time>
+<time datetime="2021-04-12" class="published">12 April 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
@@ -1469,9 +1469,10 @@ Content-Type: application/json
         <h3 id="name-down-scoped-credential-requ">
 <a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-down-scoped-credential-requ" class="section-name selfRef">Down Scoped Credential Request</a>
         </h3>
-<p id="section-3.2-1">The <code>claims</code> property, as inherited from <a href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">OIDC Core Section 5.5</a>, may be used by a holder when requesting a Credential from a CI in order to control the exact claims returned by the CI in the credential. When this parameter is not present the CI MUST return all the claims that are valid for the credential the holder is making a request for.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
-<p id="section-3.2-2">The following is a non-normative example of the decoded payload of the request making use of the claims parameter.<a href="#section-3.2-2" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-3.2-3">
+<p id="section-3.2-1">The <code>claims</code> property, as inherited from <a href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">OIDC Core Section 5.5</a>, may be used by a Credential Holder when requesting a Credential from a CI in order to control the exact claims returned by the CI in the credential. The <code>claims</code> syntax is shared with <a href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">OIDC Core Section 5.5</a> as to how to request claims but in this case does not require the <code>location</code> abstraction (e.g id<em>token/user</em>info/credential) as all claims will be returned within the <code>credential</code>.<a href="#section-3.2-1" class="pilcrow">¶</a></p>
+<p id="section-3.2-2">When this parameter is not present the CI MUST return all the claims that are valid for the credential the Credential Holder is making a request for.<a href="#section-3.2-2" class="pilcrow">¶</a></p>
+<p id="section-3.2-3">The following is a non-normative example of the decoded payload of the request making use of the claims parameter.<a href="#section-3.2-3" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-3.2-4">
 <pre>{
   "aud": "https://issuer.example.com",
   "iss": "https://wallet.example.com",
@@ -1493,7 +1494,7 @@ Content-Type: application/json
     "degree": { "essential": true }
   }
 }
-</pre><a href="#section-3.2-3" class="pilcrow">¶</a>
+</pre><a href="#section-3.2-4" class="pilcrow">¶</a>
 </div>
 </section>
 </div>

--- a/spec.md
+++ b/spec.md
@@ -236,6 +236,8 @@ The Holder may provide a signed request object containing the `sub` to be used a
 
 The Holder may also specify the `credential_format` they wish the returned credential to be formatted as. If the CI receiving the request does not support the requested credential format they it MUST return an error response, as per [TODO]. If the `credential_format` is not specified in the request the CI SHOULD respond with their preferred or default format. (Note if we are going to have a default we need to specify it or is it at the discretion of the CI to determine this?)
 
+The Holder may optionally choose to include a `claims` property within their request to down scope the set of claims returned. If not present the CI will return the complete set of claims.
+
 When a signed request is not provided the CI will use the `sub` associated with the initial Credential request, where possible. If a `sub` value is not available the CI MUST return an error response, as per [TODO].
 
 request
@@ -267,10 +269,39 @@ Where the decoded payload of the request parameter is as follows:
     "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
     "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
   },
-  "credential_format": "w3cvc-jwt",
+  "credential_format": "w3cvc-jsonld",
   "nonce": "43747d5962a5",
   "iat": 1591069056,
   "exp": 1591069556
+}
+```
+
+## Down Scoped Credential Request
+The `claims` property may be used when requesting a Credential in order to reduce the claims returned by the CI. 
+
+The following is a non-normative example of the decoded payload of the request parameter of a down scoped Signed Credential request.
+
+```
+{
+  "aud": "https://issuer.example.com",
+  "iss": "https://wallet.example.com",
+  "sub": "urn:uuid:dc000c79-6aa3-45f2-9527-43747d5962a5",
+  "sub_jwk" : {
+    "crv":"secp256k1",
+    "kid":"YkDpvGNsch2lFBf6p8u3",
+    "kty":"EC",
+    "x":"7KEKZa5xJPh7WVqHJyUpb2MgEe3nA8Rk7eUlXsmBl-M",
+    "y":"3zIgl_ml4RhapyEm5J7lvU-4f5jiBvZr4KgxUjEhl9o"
+  },
+  "credential_format": "w3cvc-jwt",
+  "nonce": "43747d5962a5",
+  "iat": 1591069056,
+  "exp": 1591069556,
+  "claims": {
+    "nickname": null,
+    "familyName": { "essential": true }
+    "degree": { "essential": true }
+  }
 }
 ```
 

--- a/spec.md
+++ b/spec.md
@@ -277,7 +277,9 @@ Where the decoded payload of the request parameter is as follows:
 ```
 
 ## Down Scoped Credential Request
-The `claims` property, as inherited from [OIDC Core Section 5.5](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter), may be used by a holder when requesting a Credential from a CI in order to control the exact claims returned by the CI in the credential. When this parameter is not present the CI MUST return all the claims that are valid for the credential the holder is making a request for. 
+The `claims` property, as inherited from [OIDC Core Section 5.5](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter), may be used by a Credential Holder when requesting a Credential from a CI in order to control the exact claims returned by the CI in the credential. The `claims` syntax is shared with [OIDC Core Section 5.5](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter) as to how to request claims but in this case does not require the `location` abstraction (e.g id_token/user_info/credential) as all claims will be returned within the `credential`.
+
+When this parameter is not present the CI MUST return all the claims that are valid for the credential the Credential Holder is making a request for. 
 
 The following is a non-normative example of the decoded payload of the request making use of the claims parameter.
 

--- a/spec.md
+++ b/spec.md
@@ -279,7 +279,7 @@ Where the decoded payload of the request parameter is as follows:
 ## Down Scoped Credential Request
 The `claims` property may be used by a holder when requesting a Credential from a CI in order to control the exact claims returned by the CI in the credential. When this parameter is not present the CI MUST return all the claims that are valid for the credential the holder is making a request for. 
 
-The following is a non-normative example of the decoded payload of the request parameter of a down scoped Signed Credential request.
+The following is a non-normative example of the decoded payload of the request making use of the claims parameter.
 
 ```
 {

--- a/spec.md
+++ b/spec.md
@@ -277,7 +277,7 @@ Where the decoded payload of the request parameter is as follows:
 ```
 
 ## Down Scoped Credential Request
-The `claims` property may be used by a holder when requesting a Credential from a CI in order to control the exact claims returned by the CI in the credential. When this parameter is not present the CI MUST return all the claims that are valid for the credential the holder is making a request for. 
+The `claims` property, as inherited from [OIDC Core Section 5.5](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter), may be used by a holder when requesting a Credential from a CI in order to control the exact claims returned by the CI in the credential. When this parameter is not present the CI MUST return all the claims that are valid for the credential the holder is making a request for. 
 
 The following is a non-normative example of the decoded payload of the request making use of the claims parameter.
 

--- a/spec.md
+++ b/spec.md
@@ -277,7 +277,7 @@ Where the decoded payload of the request parameter is as follows:
 ```
 
 ## Down Scoped Credential Request
-The `claims` property may be used when requesting a Credential in order to reduce the claims returned by the CI. 
+The `claims` property may be used by a holder when requesting a Credential from a CI in order to control the exact claims returned by the CI in the credential. When this parameter is not present the CI MUST return all the claims that are valid for the credential the holder is making a request for. 
 
 The following is a non-normative example of the decoded payload of the request parameter of a down scoped Signed Credential request.
 


### PR DESCRIPTION
@tplooker Thought about the best spot to add this... and this felt best, right at the credential endpoint so that the Holder does not need to re authenticate with the CI to change claims included in the credential.

Also thought to not nest the claims under a top level `claims.credential` property similar to common use of `claims.id_token` as it felt redundant given the request is directly to the `credential` endpoint and the only returned artefact will be the `credential`.

Also fixed format to jsonld for consistency of the main example.

Let me know what you think thanks!